### PR TITLE
Add centralized config and SEO helpers

### DIFF
--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -1,16 +1,19 @@
 ---
 import fontsHref from "../styles/fonts.css?url";
 import tailwindHref from "../styles/tailwind.css?url";
+import { canonical as buildCanonical, robots as buildRobots } from "../lib/seo";
 
 interface Props {
   title?: string;
   description?: string;
-  canonical?: string;
-  robots?: string;
+  path?: string;
+  staging?: boolean;
+  jsonLd?: any[];
 }
 
-const { title, description, canonical, robots }: Props = Astro.props;
-const robotsContent = robots ?? "index,follow";
+const { title, description, path, staging = false, jsonLd = [] }: Props = Astro.props;
+const canonical = buildCanonical(path);
+const robotsContent = buildRobots(staging);
 const currentYear = new Date().getFullYear();
 ---
 <!DOCTYPE html>
@@ -25,7 +28,11 @@ const currentYear = new Date().getFullYear();
     <link rel="preload" href="/fonts/Inter-Variable.woff2" as="font" type="font/woff2" crossorigin />
     <link rel="stylesheet" href={fontsHref} />
     <link rel="stylesheet" href={tailwindHref} />
-    <slot name="jsonld" />
+    {jsonLd.map((schema, index) => (
+      <script key={index} type="application/ld+json">
+        {JSON.stringify(schema)}
+      </script>
+    ))}
   </head>
   <body class="flex min-h-screen flex-col bg-neutral-50 text-neutral-900">
     <a

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1,0 +1,5 @@
+import siteConfig from "../../site.config.json" assert { type: "json" };
+
+export type SiteConfig = typeof siteConfig;
+
+export const config: SiteConfig = siteConfig;

--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -1,0 +1,76 @@
+import { config } from "./config";
+
+type TemplateVars = Record<string, string | number>;
+
+type TitlePage = keyof typeof config.seo.title;
+type DescriptionPage = keyof typeof config.seo.description;
+
+function applyTemplate(template: string | undefined, vars: TemplateVars = {}) {
+  if (!template) {
+    return undefined;
+  }
+
+  const mergedVars = { brand: config.site.name, ...vars };
+
+  return template.replace(/\{(.*?)\}/g, (_, key: string) => {
+    const value = mergedVars[key.trim()];
+
+    return value !== undefined ? String(value) : "";
+  });
+}
+
+export function buildTitle(page: TitlePage, vars: TemplateVars = {}) {
+  return applyTemplate(config.seo.title[page], vars);
+}
+
+export function buildDescription(page: DescriptionPage, vars: TemplateVars = {}) {
+  return applyTemplate(config.seo.description[page], vars);
+}
+
+export function canonical(path?: string) {
+  if (!config.seo.canonical) {
+    return undefined;
+  }
+
+  const base = config.site.canonicalBase.replace(/\/$/, "");
+  if (!path) {
+    return base;
+  }
+
+  return path.startsWith("/") ? `${base}${path}` : `${base}/${path}`;
+}
+
+export function robots(staging: boolean) {
+  if (staging) {
+    return "noindex,nofollow";
+  }
+
+  const { index, follow } = config.seo.robots;
+  const directives = [index ? "index" : "noindex", follow ? "follow" : "nofollow"];
+
+  return directives.join(",");
+}
+
+export function jsonld<T extends Record<string, unknown>>(type: string, data: T) {
+  return {
+    "@context": "https://schema.org",
+    "@type": type,
+    ...data,
+  };
+}
+
+export const ORG_JSONLD = jsonld("Organization", {
+  name: config.site.name,
+  url: config.site.canonicalBase,
+  sameAs: [config.site.canonicalBase],
+});
+
+export const WEBSITE_JSONLD = jsonld("WebSite", {
+  name: config.site.name,
+  url: config.site.canonicalBase,
+  potentialAction: {
+    "@type": "SearchAction",
+    target: `${config.site.canonicalBase}/zoeken?q={search_term_string}`,
+    "query-input": "required name=search_term_string",
+  },
+});


### PR DESCRIPTION
## Summary
- export the global site configuration from a central TypeScript module
- add reusable SEO utilities for meta tags and structured data
- update the Base layout to consume the canonical, robots, and JSON-LD helpers

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d7b3ccbd2c83248a1b9559ae5e8137