### PR TITLE
Add initial static marketing routes

### DIFF
--- a/site.config.json
+++ b/site.config.json
@@ -1,10 +1,129 @@
 {
-  "site":{"name":"OproepjesNederland","domain":"oproepjesnederland.nl","defaultLocale":"nl","canonicalBase":"https://oproepjesnederland.nl"},
-  "routing":{"trailingSlash":true,"routes":{"home":"/","country":"/dating-nederland/","province":"/dating-{provincie}/","provincePage":"/dating-{provincie}/page/{n}/"},"legacyRedirects":[{"from":"/nl/","to":"/dating-nederland/"},{"from":"/nl/{provincie}/","to":"/dating-{provincie}/"}]},
-  "api":{"baseUrl":"https://16hl07csd16.nl","endpoints":{"popular":"/profile/banner2/{limit}","province":"/profile/province/nl/{provincie}/{limit}"},"auth":{"type":"none","token":""},"limits":{"timeoutMs":8000,"ratePerMin":60,"pageSize":60},"deeplink":{"base":"https://chat.domein.tld/","utm":{"source":"oproepjes","medium":"referral","campaign":"provincie-{provincie}"},"subidParam":"subid"}},
-  "seo":{"title":{"home":"Adult dating per provincie | {brand}","province":"Dating in {provincie} – Profielen & chat | {brand}"},"description":{"home":"Ontdek populaire profielen per provincie en ga direct door naar de chat. Veilig, snel en 18+.","province":"Bekijk {count} profielen uit {provincie}. Klik door naar de echte chat en maak gratis een account (18+)."},"canonical":true,"sitemaps":{"main":true,"perProvince":true},"structuredData":{"itemList":true,"profileSchema":"thing"},"openGraph":{"defaultImage":"/og/default.jpg","perProvince":false},"robots":{"index":true,"follow":true}},
-  "performance":{"budget":{"jsKb":60,"cssKb":15,"imgPolicy":"webp,jpg responsive"},"cwvTargets":{"lcpMs":2500,"inpMs":200,"cls":0.1}},
-  "security":{"csp":{"imgSrc":["'self'","https:","data:"],"scriptSrc":["'self'"],"connectSrc":["https://16hl07csd16.nl"],"frameAncestors":["'none'"]},"referrerPolicy":"strict-origin-when-cross-origin"},
-  "analytics":{"tool":"plausible","domain":"oproepjesnederland.nl","events":["outbound_click","profile_impression","cta_view"],"consentMode":"cookieless"},
-  "build":{"framework":"astro","node":"20.x","packageManager":"pnpm","outDir":"dist","cron":"0 */6 * * *"}
+  "site": {
+    "name": "OproepjesNederland",
+    "domain": "oproepjesnederland.nl",
+    "defaultLocale": "nl",
+    "canonicalBase": "https://oproepjesnederland.nl"
+  },
+  "routing": {
+    "trailingSlash": true,
+    "routes": {
+      "home": "/",
+      "country": "/dating-nederland/",
+      "province": "/dating-{provincie}/",
+      "provincePage": "/dating-{provincie}/page/{n}/"
+    },
+    "legacyRedirects": [
+      {
+        "from": "/nl/",
+        "to": "/dating-nederland/"
+      },
+      {
+        "from": "/nl/{provincie}/",
+        "to": "/dating-{provincie}/"
+      }
+    ]
+  },
+  "api": {
+    "baseUrl": "https://16hl07csd16.nl",
+    "endpoints": {
+      "popular": "/profile/banner2/{limit}",
+      "province": "/profile/province/nl/{provincie}/{limit}"
+    },
+    "auth": {
+      "type": "none",
+      "token": ""
+    },
+    "limits": {
+      "timeoutMs": 8000,
+      "ratePerMin": 60,
+      "pageSize": 60
+    },
+    "deeplink": {
+      "base": "https://chat.domein.tld/",
+      "utm": {
+        "source": "oproepjes",
+        "medium": "referral",
+        "campaign": "provincie-{provincie}"
+      },
+      "subidParam": "subid"
+    }
+  },
+  "seo": {
+    "title": {
+      "home": "Adult dating per provincie | {brand}",
+      "province": "Dating in {provincie} – Profielen & chat | {brand}",
+      "generic": "{pageTitle} | {brand}"
+    },
+    "description": {
+      "home": "Ontdek populaire profielen per provincie en ga direct door naar de chat. Veilig, snel en 18+.",
+      "province": "Bekijk {count} profielen uit {provincie}. Klik door naar de echte chat en maak gratis een account (18+).",
+      "generic": "{pageDescription}"
+    },
+    "canonical": true,
+    "sitemaps": {
+      "main": true,
+      "perProvince": true
+    },
+    "structuredData": {
+      "itemList": true,
+      "profileSchema": "thing"
+    },
+    "openGraph": {
+      "defaultImage": "/og/default.jpg",
+      "perProvince": false
+    },
+    "robots": {
+      "index": true,
+      "follow": true
+    }
+  },
+  "performance": {
+    "budget": {
+      "jsKb": 60,
+      "cssKb": 15,
+      "imgPolicy": "webp,jpg responsive"
+    },
+    "cwvTargets": {
+      "lcpMs": 2500,
+      "inpMs": 200,
+      "cls": 0.1
+    }
+  },
+  "security": {
+    "csp": {
+      "imgSrc": [
+        "'self'",
+        "https:",
+        "data:"
+      ],
+      "scriptSrc": [
+        "'self'"
+      ],
+      "connectSrc": [
+        "https://16hl07csd16.nl"
+      ],
+      "frameAncestors": [
+        "'none'"
+      ]
+    },
+    "referrerPolicy": "strict-origin-when-cross-origin"
+  },
+  "analytics": {
+    "tool": "plausible",
+    "domain": "oproepjesnederland.nl",
+    "events": [
+      "outbound_click",
+      "profile_impression",
+      "cta_view"
+    ],
+    "consentMode": "cookieless"
+  },
+  "build": {
+    "framework": "astro",
+    "node": "20.x",
+    "packageManager": "pnpm",
+    "outDir": "dist",
+    "cron": "0 */6 * * *"
+  }
 }

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -8,7 +8,7 @@ interface Props {
   description?: string;
   path?: string;
   staging?: boolean;
-  jsonLd?: any[];
+  jsonLd?: Record<string, unknown>[];
 }
 
 const { title, description, path, staging = false, jsonLd = [] }: Props = Astro.props;
@@ -28,7 +28,9 @@ const currentYear = new Date().getFullYear();
     <link rel="preload" href="/fonts/Inter-Variable.woff2" as="font" type="font/woff2" crossorigin />
     <link rel="stylesheet" href={fontsHref} />
     <link rel="stylesheet" href={tailwindHref} />
-    {jsonLd.map((schema) => <script type="application/ld+json">{JSON.stringify(schema)}</script>)}
+    {jsonLd.map((schema, index) => (
+      <script type="application/ld+json" set:html={JSON.stringify(schema)} data-schema-index={index} />
+    ))}
   </head>
   <body class="flex min-h-screen flex-col bg-neutral-50 text-neutral-900">
     <a
@@ -49,8 +51,18 @@ const currentYear = new Date().getFullYear();
       <slot />
     </main>
     <footer class="border-t border-neutral-200 bg-white">
-      <div class="mx-auto max-w-5xl px-4 py-6 text-sm text-neutral-600">
-        <slot name="footer">© {currentYear} OproepjesNederland. Alle rechten voorbehouden.</slot>
+      <div class="mx-auto flex max-w-5xl flex-col gap-4 px-4 py-6 text-sm text-neutral-600 sm:flex-row sm:items-center sm:justify-between">
+        <nav aria-label="Juridische pagina's">
+          <ul class="flex flex-wrap items-center gap-x-4 gap-y-2">
+            <li><a class="transition hover:text-neutral-900" href="/privacy/">Privacy</a></li>
+            <li><a class="transition hover:text-neutral-900" href="/cookies/">Cookies</a></li>
+            <li><a class="transition hover:text-neutral-900" href="/voorwaarden/">Voorwaarden</a></li>
+            <li><a class="transition hover:text-neutral-900" href="/partners/">Partners</a></li>
+          </ul>
+        </nav>
+        <div class="text-neutral-500">
+          <slot name="footer">© {currentYear} OproepjesNederland. Alle rechten voorbehouden.</slot>
+        </div>
       </div>
     </footer>
   </body>

--- a/src/pages/404.html
+++ b/src/pages/404.html
@@ -1,0 +1,96 @@
+<!DOCTYPE html>
+<html lang="nl">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Pagina niet gevonden | OproepjesNederland</title>
+    <meta name="description" content="De opgevraagde pagina bestaat niet. Keer terug naar OproepjesNederland en start opnieuw een chat." />
+    <style>
+      :root {
+        color-scheme: light;
+      }
+      body {
+        margin: 0;
+        min-height: 100vh;
+        font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        background-color: #fafafa;
+        color: #1f2937;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        padding: 2rem;
+      }
+      .card {
+        max-width: 640px;
+        width: 100%;
+        background: #ffffff;
+        border-radius: 1.5rem;
+        box-shadow: 0 10px 40px rgba(15, 23, 42, 0.08);
+        padding: 3rem;
+        display: flex;
+        flex-direction: column;
+        gap: 1.5rem;
+        text-align: center;
+      }
+      .card h1 {
+        font-size: clamp(2rem, 4vw, 2.5rem);
+        margin: 0;
+      }
+      .card p {
+        margin: 0;
+        color: #4b5563;
+        font-size: 1rem;
+        line-height: 1.6;
+      }
+      .cta {
+        display: inline-flex;
+        align-self: center;
+        align-items: center;
+        justify-content: center;
+        background: #ef4444;
+        color: #ffffff;
+        padding: 0.75rem 1.75rem;
+        border-radius: 9999px;
+        font-weight: 600;
+        text-decoration: none;
+        box-shadow: 0 10px 25px rgba(239, 68, 68, 0.25);
+        transition: transform 0.2s ease, box-shadow 0.2s ease;
+      }
+      .cta:hover {
+        transform: translateY(-1px);
+        box-shadow: 0 12px 30px rgba(239, 68, 68, 0.35);
+      }
+      .links {
+        display: flex;
+        justify-content: center;
+        flex-wrap: wrap;
+        gap: 1rem;
+        font-size: 0.875rem;
+      }
+      .links a {
+        color: #4b5563;
+        text-decoration: none;
+      }
+      .links a:hover {
+        color: #1f2937;
+      }
+    </style>
+  </head>
+  <body>
+    <main class="card">
+      <h1>Oeps, deze pagina bestaat niet</h1>
+      <p>
+        De link die je probeerde te openen is verplaatst of verwijderd. Ga terug naar de homepage en ontdek onze laatste
+        datingoproepen per provincie.
+      </p>
+      <a class="cta" href="/dating-nederland/">Start chat — 18+</a>
+      <div class="links">
+        <a href="/">Home</a>
+        <a href="/privacy/">Privacy</a>
+        <a href="/cookies/">Cookies</a>
+        <a href="/voorwaarden/">Voorwaarden</a>
+        <a href="/partners/">Partners</a>
+      </div>
+    </main>
+  </body>
+</html>

--- a/src/pages/cookies/index.astro
+++ b/src/pages/cookies/index.astro
@@ -1,0 +1,56 @@
+---
+import Base from "../../layouts/Base.astro";
+import { buildTitle, buildDescription } from "../../lib/seo";
+
+const stagingEnv = import.meta.env.STAGING;
+const staging = stagingEnv === true || stagingEnv === "true";
+
+const title = buildTitle("generic", { pageTitle: "Cookiebeleid" });
+const description = buildDescription("generic", {
+  pageDescription: "Ontdek welke cookies we gebruiken om de website sneller en veiliger te maken voor volwassen bezoekers.",
+});
+---
+<Base title={title} description={description} path="/cookies/" staging={staging}>
+  <section class="flex flex-col gap-6 rounded-2xl bg-white p-8 shadow-sm">
+    <div class="flex flex-col gap-4">
+      <h1 class="text-3xl font-semibold text-neutral-900 sm:text-4xl">Cookiebeleid</h1>
+      <p class="text-lg text-neutral-600">
+        We houden het eenvoudig: alleen functionele en analytische cookies om je ervaring te verbeteren. Geen tracking op
+        persoonsniveau zonder expliciete toestemming.
+      </p>
+    </div>
+    <div class="flex flex-wrap items-center gap-4">
+      <a
+        href="/dating-nederland/"
+        class="inline-flex items-center justify-center rounded-full bg-accent px-6 py-3 text-base font-semibold text-white shadow transition hover:bg-accent/90"
+      >
+        Start chat — 18+
+      </a>
+      <p class="text-sm text-neutral-500">Door onze beperkte cookies blijf je anoniem en houd je controle.</p>
+    </div>
+  </section>
+
+  <section class="grid gap-6 rounded-2xl bg-white p-8 shadow-sm text-neutral-700">
+    <article class="space-y-4">
+      <h2 class="text-2xl font-semibold text-neutral-900">Soorten cookies</h2>
+      <ul class="list-disc space-y-2 pl-5">
+        <li><strong>Functioneel:</strong> nodig om de site stabiel en veilig te laten draaien.</li>
+        <li><strong>Analytics:</strong> helpt ons te begrijpen welke pagina's populair zijn zonder je te identificeren.</li>
+        <li><strong>Partnercookies:</strong> kunnen actief worden zodra je doorklikt naar een externe chatdienst.</li>
+      </ul>
+    </article>
+
+    <article class="space-y-4">
+      <h2 class="text-2xl font-semibold text-neutral-900">Cookie-instellingen beheren</h2>
+      <p>
+        Bij je eerste bezoek tonen we een duidelijke melding. Je kunt altijd je voorkeuren wijzigen via de knop
+        "Cookie-instellingen" in de footer (binnenkort beschikbaar). Voor vragen neem je contact op via
+        support@oproepjesnederland.nl.
+      </p>
+      <p>
+        Wanneer je onze partners bezoekt, kunnen aanvullende cookies gelden. Lees hun beleid om te weten welke data wordt
+        verzameld.
+      </p>
+    </article>
+  </section>
+</Base>

--- a/src/pages/dating-nederland/index.astro
+++ b/src/pages/dating-nederland/index.astro
@@ -1,0 +1,54 @@
+---
+import Base from "../../layouts/Base.astro";
+import { buildTitle, buildDescription } from "../../lib/seo";
+
+const stagingEnv = import.meta.env.STAGING;
+const staging = stagingEnv === true || stagingEnv === "true";
+
+const title = buildTitle("generic", { pageTitle: "Dating in Nederland" });
+const description = buildDescription("generic", {
+  pageDescription: "Bekijk alle provincies in Nederland en klik door naar volwassen chatsessies zonder gedoe.",
+});
+---
+<Base title={title} description={description} path="/dating-nederland/" staging={staging}>
+  <section class="flex flex-col gap-6 rounded-2xl bg-white p-8 shadow-sm">
+    <div class="flex flex-col gap-4">
+      <h1 class="text-3xl font-semibold text-neutral-900 sm:text-4xl">Dating Nederland: alle provincies in één overzicht</h1>
+      <p class="text-lg text-neutral-600">
+        Kies je provincie en ontdek welke chats er klaarstaan. We updaten dit overzicht regelmatig zodat je altijd met
+        echte locals in contact komt.
+      </p>
+    </div>
+    <div class="flex flex-wrap items-center gap-4">
+      <a
+        href="/dating-nederland/"
+        class="inline-flex items-center justify-center rounded-full bg-accent px-6 py-3 text-base font-semibold text-white shadow transition hover:bg-accent/90"
+      >
+        Start chat — 18+
+      </a>
+      <p class="text-sm text-neutral-500">Begin bij je favoriete provincie en chat direct via onze partners.</p>
+    </div>
+  </section>
+
+  <section class="grid gap-6 rounded-2xl bg-white p-8 shadow-sm">
+    <h2 class="text-2xl font-semibold text-neutral-900">Provincies (binnenkort live)</h2>
+    <p class="text-neutral-600">
+      Binnenkort tonen we hier een interactief overzicht van alle Nederlandse provincies met doorverwijzingen naar de
+      populairste profielen. We zorgen ervoor dat je snel de juiste match vindt.
+    </p>
+    <div class="grid gap-3 text-neutral-500 sm:grid-cols-2 lg:grid-cols-3">
+      <span class="rounded border border-dashed border-neutral-200 px-4 py-3 text-center">Drenthe</span>
+      <span class="rounded border border-dashed border-neutral-200 px-4 py-3 text-center">Flevoland</span>
+      <span class="rounded border border-dashed border-neutral-200 px-4 py-3 text-center">Friesland</span>
+      <span class="rounded border border-dashed border-neutral-200 px-4 py-3 text-center">Gelderland</span>
+      <span class="rounded border border-dashed border-neutral-200 px-4 py-3 text-center">Groningen</span>
+      <span class="rounded border border-dashed border-neutral-200 px-4 py-3 text-center">Limburg</span>
+      <span class="rounded border border-dashed border-neutral-200 px-4 py-3 text-center">Noord-Brabant</span>
+      <span class="rounded border border-dashed border-neutral-200 px-4 py-3 text-center">Noord-Holland</span>
+      <span class="rounded border border-dashed border-neutral-200 px-4 py-3 text-center">Overijssel</span>
+      <span class="rounded border border-dashed border-neutral-200 px-4 py-3 text-center">Utrecht</span>
+      <span class="rounded border border-dashed border-neutral-200 px-4 py-3 text-center">Zeeland</span>
+      <span class="rounded border border-dashed border-neutral-200 px-4 py-3 text-center">Zuid-Holland</span>
+    </div>
+  </section>
+</Base>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,0 +1,56 @@
+---
+import Base from "../layouts/Base.astro";
+import { buildTitle, buildDescription } from "../lib/seo";
+
+const stagingEnv = import.meta.env.STAGING;
+const staging = stagingEnv === true || stagingEnv === "true";
+
+const title = buildTitle("home");
+const description = buildDescription("home");
+---
+<Base title={title} description={description} path="/" staging={staging}>
+  <section class="flex flex-col gap-6 rounded-2xl bg-white p-8 shadow-sm">
+    <div class="flex flex-col gap-4">
+      <h1 class="text-3xl font-semibold text-neutral-900 sm:text-4xl">Vind nu je volgende chatpartner in Nederland</h1>
+      <p class="text-lg text-neutral-600">
+        OproepjesNederland brengt volwassenen bij elkaar voor een veilige en snelle chatervaring. Kies je provincie,
+        ontdek echte profielen en ga direct het gesprek aan.
+      </p>
+    </div>
+    <div class="flex flex-wrap items-center gap-4">
+      <a
+        href="/dating-nederland/"
+        class="inline-flex items-center justify-center rounded-full bg-accent px-6 py-3 text-base font-semibold text-white shadow transition hover:bg-accent/90"
+      >
+        Start chat — 18+
+      </a>
+      <p class="text-sm text-neutral-500">Gratis aanmelden, anoniem chatten en alleen voor 18+ bezoekers.</p>
+    </div>
+  </section>
+
+  <section class="grid gap-6 rounded-2xl bg-white p-8 shadow-sm">
+    <h2 class="text-2xl font-semibold text-neutral-900">Waarom kiezen voor OproepjesNederland?</h2>
+    <ul class="grid gap-4 text-neutral-600 sm:grid-cols-2">
+      <li class="rounded-xl border border-neutral-200 p-4">
+        <h3 class="text-lg font-semibold text-neutral-900">Provincie-overzicht</h3>
+        <p>Blader snel door alle provincies en ga direct door naar profielen die openstaan voor een nieuw gesprek.</p>
+      </li>
+      <li class="rounded-xl border border-neutral-200 p-4">
+        <h3 class="text-lg font-semibold text-neutral-900">Echte chats</h3>
+        <p>Onze links brengen je meteen naar de echte chatomgeving waar je 18+ matches ontmoet.</p>
+      </li>
+      <li class="rounded-xl border border-neutral-200 p-4">
+        <h3 class="text-lg font-semibold text-neutral-900">Veilige omgeving</h3>
+        <p>Geen spam of afleiding: je bepaalt zelf met wie je een gesprek begint.</p>
+      </li>
+      <li class="rounded-xl border border-neutral-200 p-4">
+        <h3 class="text-lg font-semibold text-neutral-900">Mobielvriendelijk</h3>
+        <p>Start je chat vanaf je telefoon of desktop met een intuïtieve ervaring.</p>
+      </li>
+    </ul>
+  </section>
+
+  <section id="popular" class="rounded-2xl border border-dashed border-neutral-200 bg-neutral-100 p-8 text-center text-neutral-400">
+    Populaire profielen verschijnen hier binnenkort.
+  </section>
+</Base>

--- a/src/pages/partners/index.astro
+++ b/src/pages/partners/index.astro
@@ -1,0 +1,55 @@
+---
+import Base from "../../layouts/Base.astro";
+import { buildTitle, buildDescription } from "../../lib/seo";
+
+const stagingEnv = import.meta.env.STAGING;
+const staging = stagingEnv === true || stagingEnv === "true";
+
+const title = buildTitle("generic", { pageTitle: "Partnerprogramma" });
+const description = buildDescription("generic", {
+  pageDescription: "Lees hoe we samenwerken met chatpartners en welke kwaliteitscriteria we hanteren.",
+});
+---
+<Base title={title} description={description} path="/partners/" staging={staging}>
+  <section class="flex flex-col gap-6 rounded-2xl bg-white p-8 shadow-sm">
+    <div class="flex flex-col gap-4">
+      <h1 class="text-3xl font-semibold text-neutral-900 sm:text-4xl">Partnerprogramma</h1>
+      <p class="text-lg text-neutral-600">
+        OproepjesNederland werkt samen met zorgvuldig geselecteerde chatnetwerken. We zoeken partners die discreet,
+        betrouwbaar en 18+ georiënteerd zijn.
+      </p>
+    </div>
+    <div class="flex flex-wrap items-center gap-4">
+      <a
+        href="/dating-nederland/"
+        class="inline-flex items-center justify-center rounded-full bg-accent px-6 py-3 text-base font-semibold text-white shadow transition hover:bg-accent/90"
+      >
+        Start chat — 18+
+      </a>
+      <p class="text-sm text-neutral-500">Benieuwd naar samenwerking? Mail ons op partnerships@oproepjesnederland.nl.</p>
+    </div>
+  </section>
+
+  <section class="grid gap-6 rounded-2xl bg-white p-8 shadow-sm text-neutral-700">
+    <article class="space-y-4">
+      <h2 class="text-2xl font-semibold text-neutral-900">Onze kwaliteitsstandaarden</h2>
+      <ul class="list-disc space-y-2 pl-5">
+        <li>Alle deelnemers verifiëren leeftijd en identiteit van chatoperators.</li>
+        <li>Snelle supportkanalen voor bezoekers die vragen of klachten hebben.</li>
+        <li>Heldere tarieven en transparantie over eventuele premiumfuncties.</li>
+      </ul>
+    </article>
+
+    <article class="space-y-4">
+      <h2 class="text-2xl font-semibold text-neutral-900">Samenwerken?</h2>
+      <p>
+        We staan open voor nieuwe partners die een volwassen publiek bedienen. Neem contact op met een korte introductie
+        van je platform, doelgroep en kwaliteitsmaatregelen. We reageren doorgaans binnen twee werkdagen.
+      </p>
+      <p>
+        Na goedkeuring ontvang je materiaal om je aanbod op OproepjesNederland te presenteren, inclusief trackingopties
+        voor gezamenlijke campagnes.
+      </p>
+    </article>
+  </section>
+</Base>

--- a/src/pages/privacy/index.astro
+++ b/src/pages/privacy/index.astro
@@ -1,0 +1,59 @@
+---
+import Base from "../../layouts/Base.astro";
+import { buildTitle, buildDescription } from "../../lib/seo";
+
+const stagingEnv = import.meta.env.STAGING;
+const staging = stagingEnv === true || stagingEnv === "true";
+
+const title = buildTitle("generic", { pageTitle: "Privacybeleid" });
+const description = buildDescription("generic", {
+  pageDescription: "Lees hoe OproepjesNederland omgaat met persoonsgegevens en je chatervaring beschermt.",
+});
+---
+<Base title={title} description={description} path="/privacy/" staging={staging}>
+  <section class="flex flex-col gap-6 rounded-2xl bg-white p-8 shadow-sm">
+    <div class="flex flex-col gap-4">
+      <h1 class="text-3xl font-semibold text-neutral-900 sm:text-4xl">Privacybeleid</h1>
+      <p class="text-lg text-neutral-600">
+        Jouw vertrouwen staat centraal. Dit privacybeleid licht toe welke gegevens we verzamelen, hoe we ze beveiligen en
+        hoe jij controle houdt over je informatie.
+      </p>
+    </div>
+    <div class="flex flex-wrap items-center gap-4">
+      <a
+        href="/dating-nederland/"
+        class="inline-flex items-center justify-center rounded-full bg-accent px-6 py-3 text-base font-semibold text-white shadow transition hover:bg-accent/90"
+      >
+        Start chat — 18+
+      </a>
+      <p class="text-sm text-neutral-500">We delen nooit persoonlijke gegevens met chatpartners zonder toestemming.</p>
+    </div>
+  </section>
+
+  <section class="grid gap-6 rounded-2xl bg-white p-8 shadow-sm text-neutral-700">
+    <article class="space-y-4">
+      <h2 class="text-2xl font-semibold text-neutral-900">Welke data we verwerken</h2>
+      <p>
+        OproepjesNederland werkt met minimale gegevens. We bewaren enkel de informatie die nodig is om je door te
+        verwijzen naar onze chatpartners en statistieken te verzamelen voor platformverbeteringen.
+      </p>
+      <ul class="list-disc space-y-2 pl-5">
+        <li>Technische gegevens zoals IP-adressen en browserinformatie voor beveiliging.</li>
+        <li>Anonieme analytics om te begrijpen hoe bezoekers de website gebruiken.</li>
+        <li>Optionele contactgegevens wanneer je zelf een aanvraag indient.</li>
+      </ul>
+    </article>
+
+    <article class="space-y-4">
+      <h2 class="text-2xl font-semibold text-neutral-900">Bewaartermijn & rechten</h2>
+      <p>
+        Gegevens worden niet langer bewaard dan noodzakelijk. Je kunt altijd inzage vragen in de informatie die we over
+        je hebben opgeslagen of verzoeken om verwijdering. Stuur hiervoor een e-mail naar support@oproepjesnederland.nl.
+      </p>
+      <p>
+        Wanneer je gebruikmaakt van onze partners, gelden tevens hun privacyvoorwaarden. We raden aan deze aandachtig te
+        lezen voordat je een account aanmaakt.
+      </p>
+    </article>
+  </section>
+</Base>

--- a/src/pages/voorwaarden/index.astro
+++ b/src/pages/voorwaarden/index.astro
@@ -1,0 +1,54 @@
+---
+import Base from "../../layouts/Base.astro";
+import { buildTitle, buildDescription } from "../../lib/seo";
+
+const stagingEnv = import.meta.env.STAGING;
+const staging = stagingEnv === true || stagingEnv === "true";
+
+const title = buildTitle("generic", { pageTitle: "Gebruiksvoorwaarden" });
+const description = buildDescription("generic", {
+  pageDescription: "Lees de voorwaarden van OproepjesNederland voordat je onze volwassen chatdiensten gebruikt.",
+});
+---
+<Base title={title} description={description} path="/voorwaarden/" staging={staging}>
+  <section class="flex flex-col gap-6 rounded-2xl bg-white p-8 shadow-sm">
+    <div class="flex flex-col gap-4">
+      <h1 class="text-3xl font-semibold text-neutral-900 sm:text-4xl">Gebruiksvoorwaarden</h1>
+      <p class="text-lg text-neutral-600">
+        Door OproepjesNederland te gebruiken ga je akkoord met onderstaande spelregels. We houden het veilig, respectvol
+        en exclusief voor 18+ bezoekers.
+      </p>
+    </div>
+    <div class="flex flex-wrap items-center gap-4">
+      <a
+        href="/dating-nederland/"
+        class="inline-flex items-center justify-center rounded-full bg-accent px-6 py-3 text-base font-semibold text-white shadow transition hover:bg-accent/90"
+      >
+        Start chat — 18+
+      </a>
+      <p class="text-sm text-neutral-500">Respecteer je chatpartner en meld misbruik via support@oproepjesnederland.nl.</p>
+    </div>
+  </section>
+
+  <section class="grid gap-6 rounded-2xl bg-white p-8 shadow-sm text-neutral-700">
+    <article class="space-y-4">
+      <h2 class="text-2xl font-semibold text-neutral-900">Toegang en gedrag</h2>
+      <p>
+        Deze website is uitsluitend toegankelijk voor volwassenen van 18 jaar en ouder. Ongepaste inhoud, spam of
+        discriminatie is niet toegestaan. We behouden ons het recht voor om toegang te blokkeren bij misbruik.
+      </p>
+    </article>
+
+    <article class="space-y-4">
+      <h2 class="text-2xl font-semibold text-neutral-900">Aansprakelijkheid</h2>
+      <p>
+        OproepjesNederland fungeert als doorverwijzer naar externe chatdiensten. We zijn niet verantwoordelijk voor de
+        inhoud of dienstverlening van onze partners, maar we werken uitsluitend met aanbieders die betrouwbaar zijn.
+      </p>
+      <p>
+        Door gebruik te maken van externe diensten accepteer je hun voorwaarden. Wij kunnen wijzigingen aanbrengen in dit
+        beleid zonder voorafgaande melding, dus kom regelmatig terug voor updates.
+      </p>
+    </article>
+  </section>
+</Base>


### PR DESCRIPTION
## Summary
- add generic SEO templates and update the shared layout with a legal footer navigation and JSON-LD handling
- create static home, dating overview, and legal placeholder pages that reuse the Base layout and share the Start chat — 18+ hero CTA
- provide a GitHub Pages compatible 404 page with navigation back to the main and legal sections

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d7b822731083249f2cea1c9e3d6a7b