### PR TITLE
Configure GitHub Pages deployment workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,63 @@
+name: Deploy static site to Pages
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Enable pnpm via Corepack
+        run: |
+          corepack enable
+          corepack prepare pnpm@8.15.8 --activate
+          pnpm -v
+          node -v
+
+      - name: Install deps
+        run: pnpm install --frozen-lockfile
+
+      - name: Build
+        env:
+          STAGING: "true"
+        run: pnpm build
+
+      - name: Verify build output
+        run: |
+          echo "::group::dist tree"
+          ls -lah dist || true
+          echo "::endgroup::"
+          test -f dist/index.html
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./dist
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary
- add a GitHub Pages deployment workflow that builds the site with pnpm and uploads the dist artifact
- configure the deploy job to publish the uploaded artifact to GitHub Pages

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d7bfb88f8883249a4b4b37c4ae2d6c