### PR TITLE
Add accessible Tailwind UI components

### DIFF
--- a/src/components/Alert18.astro
+++ b/src/components/Alert18.astro
@@ -1,0 +1,42 @@
+---
+const {
+  title = 'Alleen voor 18 jaar en ouder',
+  message = 'Deze dienst is uitsluitend bedoeld voor volwassenen. Door verder te gaan bevestig je dat je 18 jaar of ouder bent.',
+  continueHref = '#',
+  continueLabel = 'Ik ben 18 jaar of ouder',
+  exitHref = '/',
+  exitLabel = 'Terug naar start',
+} = Astro.props as {
+  title?: string;
+  message?: string;
+  continueHref?: string;
+  continueLabel?: string;
+  exitHref?: string;
+  exitLabel?: string;
+};
+---
+<section class="fixed inset-0 z-50 flex items-center justify-center bg-slate-900/80 px-4 py-10" role="dialog" aria-modal="true" aria-labelledby="alert18-title">
+  <div class="max-w-lg rounded-3xl border border-amber-400 bg-white p-8 text-slate-900 shadow-2xl">
+    <div class="mb-6 flex items-center gap-3">
+      <span class="inline-flex h-12 w-12 items-center justify-center rounded-full bg-amber-500 text-lg font-bold text-white" aria-hidden="true">18+</span>
+      <h2 id="alert18-title" class="text-2xl font-semibold text-slate-900">{title}</h2>
+    </div>
+    <p class="text-sm text-slate-700">{message}</p>
+    <div class="mt-8 flex flex-col gap-3 sm:flex-row sm:items-center">
+      <a
+        href={continueHref}
+        aria-label={continueLabel}
+        class="inline-flex flex-1 items-center justify-center rounded-full bg-sky-600 px-4 py-3 text-sm font-semibold text-white transition hover:bg-sky-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-400"
+      >
+        {continueLabel}
+      </a>
+      <a
+        href={exitHref}
+        aria-label={exitLabel}
+        class="inline-flex flex-1 items-center justify-center rounded-full border border-slate-300 bg-white px-4 py-3 text-sm font-semibold text-slate-800 transition hover:bg-slate-100 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-slate-500"
+      >
+        {exitLabel}
+      </a>
+    </div>
+  </div>
+</section>

--- a/src/components/Breadcrumbs.astro
+++ b/src/components/Breadcrumbs.astro
@@ -1,0 +1,33 @@
+---
+const { items = [] } = Astro.props as {
+  items?: Array<{ label: string; href?: string }>;
+};
+
+const lastIndex = items.length - 1;
+---
+{items.length > 0 && (
+  <nav aria-label="Breadcrumb" class="w-full overflow-x-auto">
+    <ol class="flex items-center gap-2 whitespace-nowrap px-4 text-sm text-slate-700">
+      {items.map((item, index) => (
+        <li class="flex items-center gap-2">
+          {item.href && index !== lastIndex ? (
+            <a
+              href={item.href}
+              class="rounded-md px-2 py-1 font-medium text-slate-700 transition hover:text-sky-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-600"
+              aria-label={`Ga naar ${item.label}`}
+            >
+              {item.label}
+            </a>
+          ) : (
+            <span class="px-2 py-1 font-semibold text-slate-900" aria-current="page">
+              {item.label}
+            </span>
+          )}
+          {index !== lastIndex && (
+            <span aria-hidden="true" class="text-slate-400">/</span>
+          )}
+        </li>
+      ))}
+    </ol>
+  </nav>
+)}

--- a/src/components/CTA.astro
+++ b/src/components/CTA.astro
@@ -1,0 +1,27 @@
+---
+const {
+  href,
+  label = 'Start chat — 18+',
+  variant = 'primary',
+} = Astro.props as {
+  href: string;
+  label?: string;
+  variant?: 'primary' | 'secondary';
+};
+
+const variants = {
+  primary:
+    'bg-sky-600 text-white hover:bg-sky-700 focus-visible:outline-sky-400',
+  secondary:
+    'bg-white text-sky-700 ring-1 ring-sky-600 hover:bg-sky-50 focus-visible:outline-sky-600',
+};
+---
+<a
+  href={href}
+  class={`inline-flex items-center justify-center gap-2 rounded-full px-6 py-3 text-base font-semibold shadow-lg transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 ${variants[variant]}`}
+  aria-label={label}
+  rel="nofollow noopener"
+>
+  <span aria-hidden="true" class="text-lg">💬</span>
+  <span>{label}</span>
+</a>

--- a/src/components/FAQ.astro
+++ b/src/components/FAQ.astro
@@ -1,0 +1,24 @@
+---
+const { items = [] } = Astro.props as {
+  items?: Array<{ id?: string; question: string; answer: string }>;
+};
+---
+<section class="mx-auto max-w-4xl space-y-4 px-4" aria-label="Veelgestelde vragen">
+  {items.map(({ id, question, answer }, index) => {
+    const itemId = id ?? `faq-${index + 1}`;
+    return (
+      <details
+        id={itemId}
+        class="group rounded-2xl border border-slate-200 bg-white p-4 transition hover:border-sky-500 hover:shadow-sm"
+      >
+        <summary class="flex cursor-pointer items-center justify-between gap-4 text-left text-base font-semibold text-slate-900 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-600">
+          <span>{question}</span>
+          <span aria-hidden="true" class="text-sky-600 transition group-open:rotate-45">+</span>
+        </summary>
+        <div class="mt-3 border-t border-slate-100 pt-3 text-sm text-slate-700">
+          <p>{answer}</p>
+        </div>
+      </details>
+    );
+  })}
+</section>

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -1,0 +1,36 @@
+---
+const { links = [], disclaimer } = Astro.props as {
+  links?: Array<{ href: string; label: string; ariaLabel?: string }>;
+  disclaimer?: string;
+};
+---
+<footer class="bg-slate-900 text-slate-100" aria-label="Voettekst">
+  <div class="mx-auto max-w-6xl px-4 py-10 flex flex-col gap-6 lg:flex-row lg:items-start lg:justify-between">
+    <div class="space-y-2 max-w-xl">
+      <p class="text-lg font-semibold">Blijf veilig online</p>
+      <p class="text-sm text-slate-300">
+        {disclaimer ?? 'Gebruik deze dienst verantwoord. Controleer altijd de identiteit van personen waarmee je contact maakt.'}
+      </p>
+    </div>
+    {links.length > 0 && (
+      <nav aria-label="Voettekst links">
+        <ul class="grid grid-cols-1 gap-2 text-sm">
+          {links.map((link) => (
+            <li>
+              <a
+                href={link.href}
+                aria-label={link.ariaLabel ?? link.label}
+                class="inline-flex items-center gap-2 rounded-md px-3 py-2 font-medium text-slate-100 transition hover:text-white hover:bg-slate-800 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-amber-400"
+              >
+                {link.label}
+              </a>
+            </li>
+          ))}
+        </ul>
+      </nav>
+    )}
+  </div>
+  <div class="bg-slate-950 text-center text-xs text-slate-400 py-4">
+    &copy; {new Date().getFullYear()} Discrete Connecties. Alle rechten voorbehouden.
+  </div>
+</footer>

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -1,0 +1,40 @@
+---
+const { title, navItems = [] } = Astro.props as {
+  title?: string;
+  navItems?: Array<{ href: string; label: string; ariaLabel?: string }>;
+};
+---
+<header class="bg-white border-b border-slate-200 text-slate-900">
+  <a
+    href="#main-content"
+    class="sr-only focus:not-sr-only focus:absolute focus:top-4 focus:left-4 focus:z-50 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-600 bg-white px-3 py-2 rounded-md shadow"
+  >
+    Skip to content
+  </a>
+  <div class="mx-auto max-w-6xl px-4 py-6 flex flex-col gap-6 lg:flex-row lg:items-center lg:justify-between">
+    <div class="flex items-center gap-3">
+      <span class="inline-flex h-12 w-12 items-center justify-center rounded-full bg-sky-600 text-white font-semibold" aria-hidden="true">18+</span>
+      <div>
+        {title && <p class="text-xl font-semibold">{title}</p>}
+        <p class="text-sm text-slate-700">Verantwoord en veilig verbinden</p>
+      </div>
+    </div>
+    {navItems.length > 0 && (
+      <nav aria-label="Hoofd navigatie">
+        <ul class="flex flex-wrap gap-3">
+          {navItems.map((item) => (
+            <li>
+              <a
+                href={item.href}
+                aria-label={item.ariaLabel ?? item.label}
+                class="inline-flex items-center rounded-md px-4 py-2 text-sm font-medium text-slate-900 transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-600 hover:text-sky-700 hover:bg-slate-100"
+              >
+                {item.label}
+              </a>
+            </li>
+          ))}
+        </ul>
+      </nav>
+    )}
+  </div>
+</header>

--- a/src/components/Pagination.astro
+++ b/src/components/Pagination.astro
@@ -1,0 +1,51 @@
+---
+const { current, total, basePath } = Astro.props as {
+  current: number;
+  total: number;
+  basePath: string;
+};
+
+const createHref = (page: number) => {
+  if (page <= 1) return basePath;
+  const url = new URL(basePath, 'https://placeholder.local');
+  url.searchParams.set('page', String(page));
+  return `${url.pathname}${url.search}`;
+};
+
+const pages = Array.from({ length: total }, (_, index) => index + 1);
+---
+{total > 1 && (
+  <nav class="flex items-center justify-center gap-2" aria-label="Paginering">
+    <a
+      href={current > 1 ? createHref(current - 1) : undefined}
+      aria-label="Vorige pagina"
+      class={`inline-flex h-10 w-10 items-center justify-center rounded-full border border-slate-300 bg-white text-slate-700 transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-600 ${current === 1 ? 'cursor-not-allowed opacity-50' : 'hover:bg-slate-100'}`}
+      aria-disabled={current === 1}
+      tabindex={current === 1 ? -1 : undefined}
+    >
+      <span aria-hidden="true">‹</span>
+    </a>
+    <ul class="flex items-center gap-1">
+      {pages.map((page) => (
+        <li>
+          <a
+            href={createHref(page)}
+            aria-current={page === current ? 'page' : undefined}
+            class={`inline-flex h-10 min-w-[2.5rem] items-center justify-center rounded-full px-3 text-sm font-semibold transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-600 ${page === current ? 'bg-sky-600 text-white' : 'bg-white text-slate-800 hover:bg-slate-100 border border-slate-300'}`}
+          >
+            {page}
+          </a>
+        </li>
+      ))}
+    </ul>
+    <a
+      href={current < total ? createHref(current + 1) : undefined}
+      aria-label="Volgende pagina"
+      class={`inline-flex h-10 w-10 items-center justify-center rounded-full border border-slate-300 bg-white text-slate-700 transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-600 ${current === total ? 'cursor-not-allowed opacity-50' : 'hover:bg-slate-100'}`}
+      aria-disabled={current === total}
+      tabindex={current === total ? -1 : undefined}
+    >
+      <span aria-hidden="true">›</span>
+    </a>
+  </nav>
+)}

--- a/src/components/ProfileCard.astro
+++ b/src/components/ProfileCard.astro
@@ -1,0 +1,66 @@
+---
+interface ProfileCardImage {
+  src: string;
+  alt: string;
+  srcset?: string;
+  sizes?: string;
+}
+
+const {
+  id,
+  name,
+  age,
+  province,
+  img,
+  deeplink,
+  description,
+} = Astro.props as {
+  id: string | number;
+  name: string;
+  age: number;
+  province: string;
+  img: ProfileCardImage;
+  deeplink: string;
+  description?: string;
+};
+---
+<article
+  class="flex h-full flex-col overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm transition hover:border-sky-500 hover:shadow-lg"
+  data-profile-id={id}
+>
+  <a
+    href={deeplink}
+    aria-label={`Bekijk profiel van ${name}`}
+    rel="nofollow sponsored noopener"
+    class="group relative block focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-600"
+  >
+    <picture class="block aspect-[4/3] overflow-hidden bg-slate-100">
+      <img
+        src={img.src}
+        alt={img.alt}
+        srcset={img.srcset}
+        sizes={img.sizes}
+        loading="lazy"
+        decoding="async"
+        class="h-full w-full object-cover transition duration-500 group-hover:scale-105"
+      />
+    </picture>
+  </a>
+  <div class="flex flex-1 flex-col gap-4 p-6 text-slate-900">
+    <div>
+      <h3 class="text-xl font-semibold text-slate-900">{name}</h3>
+      <p class="text-sm text-slate-700">{age} jaar &middot; {province}</p>
+    </div>
+    {description && <p class="text-sm text-slate-700">{description}</p>}
+    <div class="mt-auto">
+      <a
+        href={deeplink}
+        aria-label={`Start gesprek met ${name}`}
+        rel="nofollow sponsored noopener"
+        class="inline-flex items-center justify-center rounded-full bg-sky-600 px-4 py-2 text-sm font-semibold text-white transition hover:bg-sky-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-400"
+      >
+        Profiel bekijken
+      </a>
+    </div>
+  </div>
+</article>

--- a/src/components/ProvinceGrid.astro
+++ b/src/components/ProvinceGrid.astro
@@ -1,0 +1,43 @@
+---
+const { basePath = '/provincie' } = Astro.props as { basePath?: string };
+
+const provinces = [
+  'Drenthe',
+  'Flevoland',
+  'Friesland',
+  'Gelderland',
+  'Groningen',
+  'Limburg',
+  'Noord-Brabant',
+  'Noord-Holland',
+  'Overijssel',
+  'Utrecht',
+  'Zeeland',
+  'Zuid-Holland',
+];
+
+const makeSlug = (value: string) =>
+  value
+    .toLowerCase()
+    .normalize('NFD')
+    .replace(/\p{Diacritic}/gu, '')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/(^-|-$)/g, '');
+---
+<section class="mx-auto max-w-6xl px-4">
+  <div class="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
+    {provinces.map((province) => {
+      const href = `${basePath}/${makeSlug(province)}`;
+      return (
+        <a
+          href={href}
+          aria-label={`Bekijk profielen uit ${province}`}
+          class="group relative overflow-hidden rounded-xl border border-slate-200 bg-white p-6 text-slate-900 shadow-sm transition hover:border-sky-500 hover:shadow focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-600"
+        >
+          <span class="text-lg font-semibold group-hover:text-sky-700">{province}</span>
+          <span class="mt-2 block text-sm text-slate-700 group-hover:text-slate-700">Ontdek matches in {province}</span>
+        </a>
+      );
+    })}
+  </div>
+</section>


### PR DESCRIPTION
## Summary
- add reusable header, footer, CTA, and breadcrumb navigation components styled with Tailwind
- implement profile card, province grid, and pagination with accessible focus styles
- create FAQ and 18+ alert interstitial to support adult-only flows

## Testing
- pnpm lint *(fails: unable to download pnpm binary in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d7c3b75c3c8324a6380180f26174e8