### PR TITLE
Improve routing and accessibility for UI components

### DIFF
--- a/src/components/Alert18.astro
+++ b/src/components/Alert18.astro
@@ -2,20 +2,14 @@
 const {
   title = 'Alleen voor 18 jaar en ouder',
   message = 'Deze dienst is uitsluitend bedoeld voor volwassenen. Door verder te gaan bevestig je dat je 18 jaar of ouder bent.',
-  continueHref = '#',
   continueLabel = 'Ik ben 18 jaar of ouder',
   exitHref = '/',
   exitLabel = 'Terug naar start',
 } = Astro.props as {
-  title?: string;
-  message?: string;
-  continueHref?: string;
-  continueLabel?: string;
-  exitHref?: string;
-  exitLabel?: string;
+  title?: string; message?: string; continueLabel?: string; exitHref?: string; exitLabel?: string;
 };
 ---
-<section class="fixed inset-0 z-50 flex items-center justify-center bg-slate-900/80 px-4 py-10" role="dialog" aria-modal="true" aria-labelledby="alert18-title">
+<section id="alert18" class="fixed inset-0 z-50 hidden items-center justify-center bg-slate-900/80 px-4 py-10" role="dialog" aria-modal="true" aria-labelledby="alert18-title">
   <div class="max-w-lg rounded-3xl border border-amber-400 bg-white p-8 text-slate-900 shadow-2xl">
     <div class="mb-6 flex items-center gap-3">
       <span class="inline-flex h-12 w-12 items-center justify-center rounded-full bg-amber-500 text-lg font-bold text-white" aria-hidden="true">18+</span>
@@ -23,20 +17,26 @@ const {
     </div>
     <p class="text-sm text-slate-700">{message}</p>
     <div class="mt-8 flex flex-col gap-3 sm:flex-row sm:items-center">
-      <a
-        href={continueHref}
-        aria-label={continueLabel}
-        class="inline-flex flex-1 items-center justify-center rounded-full bg-sky-600 px-4 py-3 text-sm font-semibold text-white transition hover:bg-sky-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-400"
-      >
+      <button id="alert18-continue" class="inline-flex flex-1 items-center justify-center rounded-full bg-sky-600 px-4 py-3 text-sm font-semibold text-white transition hover:bg-sky-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-400">
         {continueLabel}
-      </a>
-      <a
-        href={exitHref}
-        aria-label={exitLabel}
-        class="inline-flex flex-1 items-center justify-center rounded-full border border-slate-300 bg-white px-4 py-3 text-sm font-semibold text-slate-800 transition hover:bg-slate-100 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-slate-500"
-      >
+      </button>
+      <a href={exitHref} aria-label={exitLabel} class="inline-flex flex-1 items-center justify-center rounded-full border border-slate-300 bg-white px-4 py-3 text-sm font-semibold text-slate-800 transition hover:bg-slate-100 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-slate-500">
         {exitLabel}
       </a>
     </div>
   </div>
 </section>
+
+<script>
+  const el = document.getElementById('alert18');
+  const btn = document.getElementById('alert18-continue');
+  try {
+    if (!localStorage.getItem('age_ok') && el) {
+      el.classList.remove('hidden');
+      btn?.addEventListener('click', () => {
+        localStorage.setItem('age_ok','1');
+        el.classList.add('hidden');
+      });
+    }
+  } catch {}
+</script>

--- a/src/components/CTA.astro
+++ b/src/components/CTA.astro
@@ -20,7 +20,7 @@ const variants = {
   href={href}
   class={`inline-flex items-center justify-center gap-2 rounded-full px-6 py-3 text-base font-semibold shadow-lg transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 ${variants[variant]}`}
   aria-label={label}
-  rel="nofollow noopener"
+  rel="nofollow sponsored noopener"
 >
   <span aria-hidden="true" class="text-lg">💬</span>
   <span>{label}</span>

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -31,6 +31,6 @@ const { links = [], disclaimer } = Astro.props as {
     )}
   </div>
   <div class="bg-slate-950 text-center text-xs text-slate-400 py-4">
-    &copy; {new Date().getFullYear()} Discrete Connecties. Alle rechten voorbehouden.
+    &copy; {new Date().getFullYear()} OproepjesNederland. Alle rechten voorbehouden.
   </div>
 </footer>

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -9,7 +9,7 @@ const { title, navItems = [] } = Astro.props as {
     href="#main-content"
     class="sr-only focus:not-sr-only focus:absolute focus:top-4 focus:left-4 focus:z-50 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-600 bg-white px-3 py-2 rounded-md shadow"
   >
-    Skip to content
+    Sla over naar hoofdinhoud
   </a>
   <div class="mx-auto max-w-6xl px-4 py-6 flex flex-col gap-6 lg:flex-row lg:items-center lg:justify-between">
     <div class="flex items-center gap-3">

--- a/src/components/Pagination.astro
+++ b/src/components/Pagination.astro
@@ -6,10 +6,9 @@ const { current, total, basePath } = Astro.props as {
 };
 
 const createHref = (page: number) => {
+  // basePath verwacht eindigend met slash, bv. "/dating-groningen/"
   if (page <= 1) return basePath;
-  const url = new URL(basePath, 'https://placeholder.local');
-  url.searchParams.set('page', String(page));
-  return `${url.pathname}${url.search}`;
+  return `${basePath}page/${page}/`;
 };
 
 const pages = Array.from({ length: total }, (_, index) => index + 1);

--- a/src/components/ProvinceGrid.astro
+++ b/src/components/ProvinceGrid.astro
@@ -1,41 +1,27 @@
 ---
-const { basePath = '/provincie' } = Astro.props as { basePath?: string };
-
 const provinces = [
-  'Drenthe',
-  'Flevoland',
-  'Friesland',
-  'Gelderland',
-  'Groningen',
-  'Limburg',
-  'Noord-Brabant',
-  'Noord-Holland',
-  'Overijssel',
-  'Utrecht',
-  'Zeeland',
-  'Zuid-Holland',
+  'Drenthe','Flevoland','Friesland','Gelderland','Groningen',
+  'Limburg','Noord-Brabant','Noord-Holland','Overijssel',
+  'Utrecht','Zeeland','Zuid-Holland',
 ];
 
-const makeSlug = (value: string) =>
-  value
-    .toLowerCase()
-    .normalize('NFD')
+const slug = (v: string) =>
+  v.toLowerCase().normalize('NFD')
     .replace(/\p{Diacritic}/gu, '')
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/(^-|-$)/g, '');
+    .replace(/[^a-z0-9]+/g, '-').replace(/(^-|-$)/g, '');
 ---
 <section class="mx-auto max-w-6xl px-4">
   <div class="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
-    {provinces.map((province) => {
-      const href = `${basePath}/${makeSlug(province)}`;
+    {provinces.map((p) => {
+      const href = `/dating-${slug(p)}/`;
       return (
         <a
           href={href}
-          aria-label={`Bekijk profielen uit ${province}`}
+          aria-label={`Bekijk profielen uit ${p}`}
           class="group relative overflow-hidden rounded-xl border border-slate-200 bg-white p-6 text-slate-900 shadow-sm transition hover:border-sky-500 hover:shadow focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-600"
         >
-          <span class="text-lg font-semibold group-hover:text-sky-700">{province}</span>
-          <span class="mt-2 block text-sm text-slate-700 group-hover:text-slate-700">Ontdek matches in {province}</span>
+          <span class="text-lg font-semibold group-hover:text-sky-700">{p}</span>
+          <span class="mt-2 block text-sm text-slate-700">Ontdek matches in {p}</span>
         </a>
       );
     })}

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -2,19 +2,25 @@
 import fontsHref from "../styles/fonts.css?url";
 import tailwindHref from "../styles/tailwind.css?url";
 import { canonical as buildCanonical, robots as buildRobots } from "../lib/seo";
+import Header from "../components/Header.astro";
+import Footer from "../components/Footer.astro";
 
 interface Props {
-  title?: string;
-  description?: string;
-  path?: string;
-  staging?: boolean;
-  jsonLd?: Record<string, unknown>[];
+  title?: string; description?: string; path?: string; staging?: boolean; jsonLd?: any[];
 }
-
 const { title, description, path, staging = false, jsonLd = [] }: Props = Astro.props;
 const canonical = buildCanonical(path);
 const robotsContent = buildRobots(staging);
 const currentYear = new Date().getFullYear();
+
+const navItems = [
+  { href: "/", label: "Home" },
+  { href: "/dating-nederland/", label: "Overzicht NL" },
+  { href: "/privacy/", label: "Privacy" },
+  { href: "/cookies/", label: "Cookies" },
+  { href: "/voorwaarden/", label: "Voorwaarden" },
+  { href: "/partners/", label: "Partners" },
+];
 ---
 <!DOCTYPE html>
 <html lang="nl">
@@ -28,42 +34,16 @@ const currentYear = new Date().getFullYear();
     <link rel="preload" href="/fonts/Inter-Variable.woff2" as="font" type="font/woff2" crossorigin />
     <link rel="stylesheet" href={fontsHref} />
     <link rel="stylesheet" href={tailwindHref} />
-    {jsonLd.map((schema, index) => (
-      <script type="application/ld+json" set:html={JSON.stringify(schema)} data-schema-index={index} />
-    ))}
+    {jsonLd.map((schema) => <script type="application/ld+json">{JSON.stringify(schema)}</script>)}
   </head>
   <body class="flex min-h-screen flex-col bg-neutral-50 text-neutral-900">
-    <a
-      class="sr-only focus:not-sr-only focus:absolute focus:top-4 focus:left-4 focus:rounded focus:bg-white focus:px-4 focus:py-2 focus:text-accent"
-      href="#content"
-    >
-      Sla over naar hoofdinhoud
-    </a>
-    <header class="border-b border-neutral-200 bg-white">
-      <div class="mx-auto flex max-w-5xl items-center justify-between gap-4 px-4 py-6">
-        <div class="flex items-center gap-3">
-          <span class="text-lg font-semibold uppercase tracking-wide text-neutral-900">OproepjesNederland</span>
-          <span class="inline-flex items-center rounded-full bg-accent px-2 py-1 text-xs font-bold uppercase tracking-wide text-white">18+</span>
-        </div>
-      </div>
-    </header>
-    <main id="content" class="mx-auto flex w-full max-w-5xl flex-1 flex-col gap-8 px-4 py-8">
+    <Header title="OproepjesNederland" navItems={navItems} />
+    <main id="main-content" class="mx-auto flex w-full max-w-5xl flex-1 flex-col gap-8 px-4 py-8">
       <slot />
     </main>
-    <footer class="border-t border-neutral-200 bg-white">
-      <div class="mx-auto flex max-w-5xl flex-col gap-4 px-4 py-6 text-sm text-neutral-600 sm:flex-row sm:items-center sm:justify-between">
-        <nav aria-label="Juridische pagina's">
-          <ul class="flex flex-wrap items-center gap-x-4 gap-y-2">
-            <li><a class="transition hover:text-neutral-900" href="/privacy/">Privacy</a></li>
-            <li><a class="transition hover:text-neutral-900" href="/cookies/">Cookies</a></li>
-            <li><a class="transition hover:text-neutral-900" href="/voorwaarden/">Voorwaarden</a></li>
-            <li><a class="transition hover:text-neutral-900" href="/partners/">Partners</a></li>
-          </ul>
-        </nav>
-        <div class="text-neutral-500">
-          <slot name="footer">© {currentYear} OproepjesNederland. Alle rechten voorbehouden.</slot>
-        </div>
-      </div>
-    </footer>
+    <Footer
+      links={navItems}
+      disclaimer="Gebruik deze dienst verantwoord. 18+."
+    />
   </body>
 </html>


### PR DESCRIPTION
## Summary
- update province grid cards with normalized slugs and improved hover states
- adjust pagination links to use clean `/page/<n>/` routing
- enhance CTA, header, footer, layout, and 18+ alert for compliance and accessibility

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d7c61f0b488324a0fffa606e2006a7