### PR TITLE
Add static province dating pages

### DIFF
--- a/src/pages/dating-[provincie].astro
+++ b/src/pages/dating-[provincie].astro
@@ -1,0 +1,59 @@
+---
+import Base from "../layouts/Base.astro";
+import { buildTitle, buildDescription, jsonld } from "../lib/seo";
+
+const provinces = [
+  "Drenthe","Flevoland","Friesland","Gelderland","Groningen",
+  "Limburg","Noord-Brabant","Noord-Holland","Overijssel",
+  "Utrecht","Zeeland","Zuid-Holland"
+];
+
+const slugify = (v: string) =>
+  v.toLowerCase()
+   .normalize("NFD")
+   .replace(/\p{Diacritic}/gu, "")
+   .replace(/[^a-z0-9]+/g, "-")
+   .replace(/(^-|-$)/g, "");
+
+export function getStaticPaths() {
+  return provinces.map((name) => {
+    const slug = slugify(name);
+    return {
+      params: { provincie: slug },
+      props: { name, slug }
+    };
+  });
+}
+
+interface Props { name: string; slug: string; }
+const { name, slug } = Astro.props as Props;
+
+// SEO
+const path = `/dating-${slug}/`;
+const title = buildTitle("province", { provincie: name });
+const description = buildDescription("province", { provincie: name, count: 0 });
+
+// JSON-LD (ItemList leeg v1)
+const itemList = jsonld("ItemList", {
+  name: `Profielen in ${name}`,
+  itemListElement: []
+});
+---
+<Base title={title} description={description} path={path} staging={import.meta.env.STAGING} jsonLd={[itemList]}>
+  <section class="mx-auto max-w-5xl space-y-6">
+    <h1 class="text-3xl font-bold text-neutral-900">Profielen in {name}</h1>
+    <p class="text-neutral-700">Hier verschijnen de populairste profielen uit {name}. De lijst wordt later gevuld via de API.</p>
+
+    <!-- Placeholder voor profielenlijst -->
+    <div class="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3" aria-live="polite" aria-busy="false">
+      <div class="h-52 animate-pulse rounded-xl bg-neutral-200"></div>
+      <div class="h-52 animate-pulse rounded-xl bg-neutral-200"></div>
+      <div class="h-52 animate-pulse rounded-xl bg-neutral-200"></div>
+    </div>
+
+    <!-- Paginatie placeholder: /page/{n}/ komt later -->
+    <nav aria-label="Paginatie" class="mt-6">
+      <a href="#" class="pointer-events-none inline-flex items-center rounded-full bg-neutral-200 px-4 py-2 text-neutral-500">Paginatie volgt</a>
+    </nav>
+  </section>
+</Base>


### PR DESCRIPTION
## Summary
- add a dynamic Astro route that emits statically generated dating pages for each Dutch province with placeholder content

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d7ca5e7cd483248d69b9d8a15bc3d0