### PR TITLE
Fix static province list for dating pages

### DIFF
--- a/src/pages/dating-[provincie].astro
+++ b/src/pages/dating-[provincie].astro
@@ -2,26 +2,22 @@
 import Base from "../layouts/Base.astro";
 import { buildTitle, buildDescription, jsonld } from "../lib/seo";
 
-const provinces = [
-  "Drenthe","Flevoland","Friesland","Gelderland","Groningen",
-  "Limburg","Noord-Brabant","Noord-Holland","Overijssel",
-  "Utrecht","Zeeland","Zuid-Holland"
-];
-
-const slugify = (v: string) =>
-  v.toLowerCase()
-   .normalize("NFD")
-   .replace(/\p{Diacritic}/gu, "")
-   .replace(/[^a-z0-9]+/g, "-")
-   .replace(/(^-|-$)/g, "");
-
 export function getStaticPaths() {
-  return provinces.map((name) => {
-    const slug = slugify(name);
-    return {
-      params: { provincie: slug },
-      props: { name, slug }
-    };
+  const PROVINCES = [
+    "Drenthe","Flevoland","Friesland","Gelderland","Groningen",
+    "Limburg","Noord-Brabant","Noord-Holland","Overijssel",
+    "Utrecht","Zeeland","Zuid-Holland"
+  ];
+
+  const slug = (v) =>
+    v.toLowerCase()
+      .replace(/\s+/g, "-")
+      .replace(/[^a-z0-9-]/g, "")
+      .replace(/(^-|-$)/g, "");
+
+  return PROVINCES.map((name) => {
+    const s = slug(name);
+    return { params: { provincie: s }, props: { name, slug: s } };
   });
 }
 


### PR DESCRIPTION
## Summary
- define the provinces list within `getStaticPaths`
- regenerate the slug helper locally inside the function and return params/props for each province

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d7cc3b26608324a3ec62207c535418