### PR TITLE
Fix province page lib imports

### DIFF
--- a/src/pages/dating-[provincie]/page/[page]/index.astro
+++ b/src/pages/dating-[provincie]/page/[page]/index.astro
@@ -1,8 +1,8 @@
 ---
 import PageView from "../../PageView.astro";
-import { config } from "../../../lib/config";
-import { getProvince } from "../../../lib/api";
-import { PROVINCES, provinceToSlug } from "../../../lib/provinces";
+import { config } from "../../../../lib/config";
+import { getProvince } from "../../../../lib/api";
+import { PROVINCES, provinceToSlug } from "../../../../lib/provinces";
 
 const pageSize = config.api.limits?.pageSize ?? 60;
 


### PR DESCRIPTION
## Summary
- correct the province pagination page to import lib modules from the proper relative path

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d7cff783608324bd7ee0513dd4ef1b