### PR TITLE
Fix page size scope in province pagination page

### DIFF
--- a/src/pages/dating-[provincie]/page/[page]/index.astro
+++ b/src/pages/dating-[provincie]/page/[page]/index.astro
@@ -4,9 +4,8 @@ import { config } from "../../../../lib/config";
 import { getProvince } from "../../../../lib/api";
 import { PROVINCES, provinceToSlug } from "../../../../lib/provinces";
 
-const pageSize = config.api.limits?.pageSize ?? 60;
-
 export async function getStaticPaths() {
+  const pageSize = config.api.limits?.pageSize ?? 60;
   const paths = [] as Array<{
     params: { provincie: string; page: string };
     props: {
@@ -50,6 +49,7 @@ interface Props {
 }
 
 const { provinceName, slug, currentPage, totalPages } = Astro.props as Props;
+const pageSize = config.api.limits?.pageSize ?? 60;
 const data = await getProvince(provinceName, pageSize, currentPage);
 
 const totalCount = data.totalCount ?? data.profiles.length;


### PR DESCRIPTION
## Summary
- move pageSize definition inside getStaticPaths to ensure availability during prerendering
- reintroduce pageSize constant in the main module before fetching province data

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d7d0a3adc48324b112c5b561533e75