### PR TITLE
Move dating province PageView to views component

### DIFF
--- a/src/pages/dating-[provincie]/index.astro
+++ b/src/pages/dating-[provincie]/index.astro
@@ -1,5 +1,5 @@
 ---
-import PageView from "./PageView.astro";
+import PageView from "../../../views/PageView.astro";
 import { config } from "../../lib/config";
 import { getProvince } from "../../lib/api";
 import { PROVINCES, provinceToSlug } from "../../lib/provinces";

--- a/src/pages/dating-[provincie]/page/[page]/index.astro
+++ b/src/pages/dating-[provincie]/page/[page]/index.astro
@@ -1,5 +1,5 @@
 ---
-import PageView from "../../PageView.astro";
+import PageView from "../../../../../views/PageView.astro";
 import { config } from "../../../../lib/config";
 import { getProvince } from "../../../../lib/api";
 import { PROVINCES, provinceToSlug } from "../../../../lib/provinces";

--- a/src/views/PageView.astro
+++ b/src/views/PageView.astro
@@ -1,9 +1,9 @@
 ---
-import Base from "../../layouts/Base.astro";
-import ProfileCard from "../../components/ProfileCard.astro";
-import Pagination from "../../components/Pagination.astro";
-import { buildTitle, buildDescription, jsonld } from "../../lib/seo";
-import type { Profile } from "../../lib/api";
+import Base from "../layouts/Base.astro";
+import ProfileCard from "../components/ProfileCard.astro";
+import Pagination from "../components/Pagination.astro";
+import { buildTitle, buildDescription, jsonld } from "../lib/seo";
+import type { Profile } from "../lib/api";
 
 interface Props {
   provinceName: string;


### PR DESCRIPTION
## Summary
- move the dating province PageView into `src/views`
- update the dating province route files to import the shared view component

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d7d28df9008324ae7e69da3cb057cf