### PR TITLE
Fix province casing for API endpoints

### DIFF
--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import { config } from "./config";
-import { provinceToSlug } from "./provinces";
+import { provinceToSlug, canonicalProvince } from "./provinces";
 import { mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
@@ -12,11 +12,11 @@ export const endpoints = {
   popular: (limit: number) =>
     `${BASE}${endpointTemplates.popular.replace("{limit}", encodeURIComponent(String(limit)))}`,
   province: (province: string, limit: number, page: number) => {
-    const slug = provinceToSlug(province);
+    // API wil exacte casing zoals "Drenthe", "Noord-Holland"
+    const canonical = canonicalProvince(province);
     const path = endpointTemplates.province
-      .replace("{provincie}", encodeURIComponent(slug))
+      .replace("{provincie}", encodeURIComponent(canonical))
       .replace("{limit}", encodeURIComponent(String(limit)));
-    // Sommige APIs ondersteunen ?page, andere niet; alleen toevoegen >1
     const url = new URL(`${BASE}${path}`);
     if (page > 1) url.searchParams.set("page", String(page));
     return url.toString();

--- a/src/lib/provinces.ts
+++ b/src/lib/provinces.ts
@@ -22,3 +22,11 @@ export function provinceToSlug(name: string) {
     .replace(/[^\p{Letter}\p{Number}]+/gu, "-")
     .replace(/^-+|-+$/g, "");
 }
+
+export function canonicalProvince(input: string) {
+  const inputSlug = provinceToSlug(input);
+  for (const name of PROVINCES) {
+    if (provinceToSlug(name) === inputSlug) return name; // exact-cased naam
+  }
+  return input; // fallback
+}


### PR DESCRIPTION
## Summary
- add a helper to map province slugs back to their canonical casing
- update province endpoint builder to send canonical province names to the API

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d7deb812f88324a27b548e594cc71e