### PR TITLE
Add SEO metadata and sitemap handling

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,8 +1,34 @@
-import { defineConfig } from 'astro/config';
-import tailwind from '@astrojs/tailwind';
+import { defineConfig } from "astro/config";
+import tailwind from "@astrojs/tailwind";
+import siteConfig from "./site.config.json" assert { type: "json" };
+import { writeFile } from "node:fs/promises";
+
+const stagingValue = process.env.STAGING;
+const isStagingEnv =
+  typeof stagingValue === "string"
+    ? ["true", "1", "yes"].includes(stagingValue.toLowerCase())
+    : Boolean(stagingValue);
+
+const robotsIntegration = {
+  name: "robots-env-toggle",
+  hooks: {
+    "astro:build:done": async ({ dir }) => {
+      if (!isStagingEnv) return;
+
+      const robotsUrl = new URL("./robots.txt", dir);
+      const content = "User-agent: *\nDisallow: /\n";
+
+      try {
+        await writeFile(robotsUrl, content, "utf8");
+      } catch (error) {
+        console.warn("Kon staging robots.txt niet schrijven", error);
+      }
+    },
+  },
+};
 
 export default defineConfig({
-  site: "https://placeholder.example.com",
+  site: siteConfig.site?.canonicalBase ?? "https://placeholder.example.com",
   trailingSlash: "always",
-  integrations: [tailwind()],
+  integrations: [tailwind(), robotsIntegration],
 });

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://oproepjesnederland.nl/sitemap.xml

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -2,7 +2,7 @@
 import Base from "../layouts/Base.astro";
 import ProfileCard from "../components/ProfileCard.astro";
 import { getPopular, type Profile } from "../lib/api";
-import { buildTitle, buildDescription } from "../lib/seo";
+import { buildTitle, buildDescription, ORG_JSONLD, WEBSITE_JSONLD } from "../lib/seo";
 
 const stagingEnv = import.meta.env.STAGING;
 const staging = stagingEnv === true || stagingEnv === "true";
@@ -18,7 +18,13 @@ try {
   console.error("[home] Fout bij ophalen populaire profielen", error);
 }
 ---
-<Base title={title} description={description} path="/" staging={staging}>
+<Base
+  title={title}
+  description={description}
+  path="/"
+  staging={staging}
+  jsonLd={[ORG_JSONLD, WEBSITE_JSONLD]}
+>
   <section class="flex flex-col gap-6 rounded-2xl bg-white p-8 shadow-sm">
     <div class="flex flex-col gap-4">
       <h1 class="text-3xl font-semibold text-neutral-900 sm:text-4xl">Vind nu je volgende chatpartner in Nederland</h1>

--- a/src/pages/sitemap.xml.ts
+++ b/src/pages/sitemap.xml.ts
@@ -1,0 +1,65 @@
+import type { APIRoute } from "astro";
+import { config } from "../lib/config";
+import { PROVINCES, provinceToSlug } from "../lib/provinces";
+import { getProvince } from "../lib/api";
+
+export const prerender = true;
+
+const CHANGE_FREQUENCY = "daily";
+const HOME_PRIORITY = "0.8";
+const PROVINCE_PRIORITY = "0.7";
+const PAGINATED_PRIORITY = "0.5";
+
+function normaliseBaseUrl(url: string) {
+  return url.replace(/\/$/, "");
+}
+
+function absoluteUrl(base: string, path: string) {
+  if (path === "/") return `${base}/`;
+  return `${base}${path}`;
+}
+
+export const GET: APIRoute = async () => {
+  const baseUrl = normaliseBaseUrl(config.site.canonicalBase ?? "");
+  const pageSize = config.api.limits?.pageSize ?? 60;
+
+  const urls: Array<{ loc: string; priority: string }> = [
+    { loc: absoluteUrl(baseUrl, "/"), priority: HOME_PRIORITY },
+    { loc: absoluteUrl(baseUrl, "/dating-nederland/"), priority: PROVINCE_PRIORITY },
+  ];
+
+  const provinceEntries = await Promise.all(
+    PROVINCES.map(async (provinceName) => {
+      const slug = provinceToSlug(provinceName);
+      const firstPage = await getProvince(provinceName, pageSize, 1);
+      const totalPages = Math.max(1, firstPage.totalPages ?? 1);
+      return { slug, totalPages };
+    })
+  );
+
+  for (const { slug, totalPages } of provinceEntries) {
+    const basePath = `/dating-${slug}/`;
+    urls.push({ loc: absoluteUrl(baseUrl, basePath), priority: PROVINCE_PRIORITY });
+
+    for (let page = 2; page <= totalPages; page++) {
+      const pagePath = `${basePath}page/${page}/`;
+      urls.push({ loc: absoluteUrl(baseUrl, pagePath), priority: PAGINATED_PRIORITY });
+    }
+  }
+
+  const body = `<?xml version="1.0" encoding="UTF-8"?>\n` +
+    `<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n` +
+    urls
+      .map(
+        ({ loc, priority }) =>
+          `  <url>\n    <loc>${loc}</loc>\n    <changefreq>${CHANGE_FREQUENCY}</changefreq>\n    <priority>${priority}</priority>\n  </url>`
+      )
+      .join("\n") +
+    "\n</urlset>\n";
+
+  return new Response(body, {
+    headers: {
+      "Content-Type": "application/xml; charset=utf-8",
+    },
+  });
+};

--- a/src/views/PageView.astro
+++ b/src/views/PageView.astro
@@ -26,16 +26,20 @@ const description = buildDescription("province", { provincie: provinceName, coun
 const listStartIndex = (currentPage - 1) * pageSize;
 
 const itemListElement = profiles.map((profile, index) => {
-  const item: Record<string, unknown> = {
+  const listItem: Record<string, unknown> = {
     "@type": "ListItem",
     position: listStartIndex + index + 1,
-    url: profile.deeplink,
-    name: profile.name,
+    item: {
+      "@type": "Thing",
+      name: profile.name,
+    },
   };
+
   if (profile.description) {
-    item.description = profile.description;
+    (listItem.item as Record<string, unknown>).description = profile.description;
   }
-  return item;
+
+  return listItem;
 });
 
 const itemListSchema = jsonld("ItemList", {


### PR DESCRIPTION
## Summary
- embed Organization and WebSite JSON-LD on the home page and adjust province ItemList markup to match the required structure
- add a prerendered sitemap endpoint that lists the home, national overview, provinces, and paginated province pages with the requested priorities
- configure robots.txt to allow production crawling while overwriting it during staging builds

## Testing
- pnpm lint *(fails: registry fetch blocked in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d7e32e24d48324a5c1a0bdf18990ad