### PR TITLE
Add Plausible tracking for outbound profile clicks

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -34,3 +34,23 @@ const { links = [], disclaimer } = Astro.props as {
     &copy; {new Date().getFullYear()} OproepjesNederland. Alle rechten voorbehouden.
   </div>
 </footer>
+<script is:inline>
+  if (typeof window !== "undefined") {
+    window.addEventListener("click", (event) => {
+      const origin = event.target;
+      if (!origin || !(origin instanceof Element)) return;
+      const target = origin.closest('[data-analytics="outbound_click"]');
+      if (!target) return;
+      const raw = target.getAttribute("data-props");
+      if (!raw) return;
+      try {
+        const props = JSON.parse(raw);
+        if (typeof window.plausible === "function") {
+          window.plausible("outbound_click", { props });
+        }
+      } catch (_error) {
+        return;
+      }
+    });
+  }
+</script>

--- a/src/components/ProfileCard.astro
+++ b/src/components/ProfileCard.astro
@@ -56,6 +56,7 @@ const {
   img,
   deeplink,
   description,
+  rank,
 } = Astro.props as {
   id: string | number;
   name: string;
@@ -64,11 +65,18 @@ const {
   img: ProfileCardImage;
   deeplink: string;
   description?: string;
+  rank?: number;
 };
 
 const responsiveSrcset = ensureResponsiveSrcset(img.src, img.srcset);
 const responsiveSizes =
   img.sizes ?? "(min-width: 1024px) 25vw, (min-width: 768px) 33vw, 100vw";
+const analyticsProps = JSON.stringify({
+  chat_url: deeplink,
+  province,
+  rank,
+  profile_id: String(id),
+});
 ---
 <article
   class="flex h-full flex-col overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm transition hover:border-sky-500 hover:shadow-lg"
@@ -79,6 +87,8 @@ const responsiveSizes =
     aria-label={`Bekijk profiel van ${name}`}
     rel="nofollow sponsored noopener"
     class="group relative block focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-600"
+    data-analytics="outbound_click"
+    data-props={analyticsProps}
   >
     <picture
       class="block aspect-[4/3] overflow-hidden bg-slate-100"
@@ -107,6 +117,8 @@ const responsiveSizes =
         aria-label={`Start gesprek met ${name}`}
         rel="nofollow sponsored noopener"
         class="inline-flex items-center justify-center rounded-full bg-sky-600 px-4 py-2 text-sm font-semibold text-white transition hover:bg-sky-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-400"
+        data-analytics="outbound_click"
+        data-props={analyticsProps}
       >
         Profiel bekijken
       </a>

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -36,6 +36,7 @@ const navItems = [
     <link rel="stylesheet" href={fontsHref} />
     <link rel="stylesheet" href={tailwindHref} />
     {jsonLd.map((schema) => <script type="application/ld+json">{JSON.stringify(schema)}</script>)}
+    <script defer data-domain="oproepjesnederland.nl" src="https://plausible.io/js/script.js"></script>
   </head>
   <body class="flex min-h-screen flex-col bg-neutral-50 text-neutral-900">
     <Header title="OproepjesNederland" navItems={navItems} />

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -82,8 +82,8 @@ try {
 
     {popularProfiles.length > 0 ? (
       <div class="grid grid-cols-1 gap-6 sm:grid-cols-2 xl:grid-cols-3">
-        {popularProfiles.map((profile) => (
-          <ProfileCard {...profile} key={profile.id} />
+        {popularProfiles.map((profile, index) => (
+          <ProfileCard {...profile} key={profile.id} rank={index + 1} />
         ))}
       </div>
     ) : (

--- a/src/views/PageView.astro
+++ b/src/views/PageView.astro
@@ -66,7 +66,9 @@ const itemListSchema = jsonld("ItemList", {
       {profiles.length === 0 ? (
         <p class="col-span-full text-neutral-600">Momenteel zijn er geen profielen beschikbaar in deze provincie.</p>
       ) : (
-        profiles.map((profile) => <ProfileCard {...profile} />)
+        profiles.map((profile, index) => (
+          <ProfileCard {...profile} rank={listStartIndex + index + 1} />
+        ))
       )}
     </div>
 


### PR DESCRIPTION
## Summary
- add the Plausible analytics script tag to the base layout
- tag profile card links with outbound click metadata including rank information
- ship a lightweight inline footer script to forward outbound click events to Plausible

## Testing
- pnpm lint *(fails: cannot download pnpm due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68d7e7f6b8688324ad3f801c0a6d35e6