### PR TITLE
Add accessible 18+ interstitial gate

### DIFF
--- a/src/components/Alert18.astro
+++ b/src/components/Alert18.astro
@@ -1,15 +1,25 @@
 ---
 const {
-  title = 'Alleen voor 18 jaar en ouder',
-  message = 'Deze dienst is uitsluitend bedoeld voor volwassenen. Door verder te gaan bevestig je dat je 18 jaar of ouder bent.',
-  continueLabel = 'Ik ben 18 jaar of ouder',
+  title = 'Bevestig je leeftijd',
+  message = 'Deze site is alleen voor 18+. Ga verder als je dat bent.',
+  continueLabel = 'Ik ben 18+',
   exitHref = '/',
-  exitLabel = 'Terug naar start',
+  exitLabel = 'Verlaat',
 } = Astro.props as {
-  title?: string; message?: string; continueLabel?: string; exitHref?: string; exitLabel?: string;
+  title?: string;
+  message?: string;
+  continueLabel?: string;
+  exitHref?: string;
+  exitLabel?: string;
 };
 ---
-<section id="alert18" class="fixed inset-0 z-50 hidden items-center justify-center bg-slate-900/80 px-4 py-10" role="dialog" aria-modal="true" aria-labelledby="alert18-title">
+<section
+  id="alert18"
+  class="fixed inset-0 z-50 hidden items-center justify-center bg-slate-900/80 px-4 py-10"
+  role="dialog"
+  aria-modal="true"
+  aria-labelledby="alert18-title"
+>
   <div class="max-w-lg rounded-3xl border border-amber-400 bg-white p-8 text-slate-900 shadow-2xl">
     <div class="mb-6 flex items-center gap-3">
       <span class="inline-flex h-12 w-12 items-center justify-center rounded-full bg-amber-500 text-lg font-bold text-white" aria-hidden="true">18+</span>
@@ -17,26 +27,92 @@ const {
     </div>
     <p class="text-sm text-slate-700">{message}</p>
     <div class="mt-8 flex flex-col gap-3 sm:flex-row sm:items-center">
-      <button id="alert18-continue" class="inline-flex flex-1 items-center justify-center rounded-full bg-sky-600 px-4 py-3 text-sm font-semibold text-white transition hover:bg-sky-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-400">
+      <button
+        id="alert18-continue"
+        type="button"
+        aria-label="Bevestig dat je 18 jaar of ouder bent"
+        class="inline-flex flex-1 items-center justify-center rounded-full bg-sky-600 px-4 py-3 text-sm font-semibold text-white transition hover:bg-sky-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-400"
+      >
         {continueLabel}
       </button>
-      <a href={exitHref} aria-label={exitLabel} class="inline-flex flex-1 items-center justify-center rounded-full border border-slate-300 bg-white px-4 py-3 text-sm font-semibold text-slate-800 transition hover:bg-slate-100 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-slate-500">
+      <a
+        id="alert18-exit"
+        href={exitHref}
+        aria-label="Verlaat de website"
+        class="inline-flex flex-1 items-center justify-center rounded-full border border-slate-300 bg-white px-4 py-3 text-sm font-semibold text-slate-800 transition hover:bg-slate-100 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-slate-500"
+      >
         {exitLabel}
       </a>
     </div>
   </div>
 </section>
 
-<script>
-  const el = document.getElementById('alert18');
-  const btn = document.getElementById('alert18-continue');
+<script is:inline>
+  const storageKey = 'age_ok';
+  const modal = document.getElementById('alert18');
+  const continueBtn = document.getElementById('alert18-continue');
+  const exitBtn = document.getElementById('alert18-exit');
+  const focusableSelector = 'a[href], button:not([disabled]), [tabindex]:not([tabindex="-1"])';
+  let lastFocusedElement = null;
+
+  const getFocusable = () => modal ? Array.from(modal.querySelectorAll(focusableSelector)) : [];
+
+  const trapFocus = (event) => {
+    if (!modal || modal.classList.contains('hidden')) return;
+    if (event.key === 'Escape') {
+      event.preventDefault();
+      exitBtn?.focus();
+      return;
+    }
+    if (event.key !== 'Tab') return;
+    const focusableElements = getFocusable();
+    if (focusableElements.length === 0) return;
+    const first = focusableElements[0];
+    const last = focusableElements[focusableElements.length - 1];
+
+    if (event.shiftKey) {
+      if (document.activeElement === first) {
+        event.preventDefault();
+        last.focus();
+      }
+    } else if (document.activeElement === last) {
+      event.preventDefault();
+      first.focus();
+    }
+  };
+
+  const closeModal = () => {
+    if (!modal) return;
+    modal.classList.add('hidden');
+    document.removeEventListener('keydown', trapFocus);
+    if (lastFocusedElement instanceof HTMLElement) {
+      lastFocusedElement.focus();
+    }
+  };
+
   try {
-    if (!localStorage.getItem('age_ok') && el) {
-      el.classList.remove('hidden');
-      btn?.addEventListener('click', () => {
-        localStorage.setItem('age_ok','1');
-        el.classList.add('hidden');
+    if (modal && !localStorage.getItem(storageKey)) {
+      lastFocusedElement = document.activeElement;
+      modal.classList.remove('hidden');
+      document.addEventListener('keydown', trapFocus);
+      requestAnimationFrame(() => {
+        continueBtn?.focus();
+      });
+
+      continueBtn?.addEventListener('click', () => {
+        try {
+          localStorage.setItem(storageKey, '1');
+        } catch (error) {
+          console.warn('Kon leeftijdscontrole niet opslaan', error);
+        }
+        closeModal();
+      });
+
+      exitBtn?.addEventListener('click', () => {
+        document.removeEventListener('keydown', trapFocus);
       });
     }
-  } catch {}
+  } catch (error) {
+    console.warn('Leeftijdscontrole niet beschikbaar', error);
+  }
 </script>

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -4,14 +4,22 @@ import tailwindHref from "../styles/tailwind.css?url";
 import { canonical as buildCanonical, robots as buildRobots } from "../lib/seo";
 import Header from "../components/Header.astro";
 import Footer from "../components/Footer.astro";
+import Alert18 from "../components/Alert18.astro";
 
 interface Props {
-  title?: string; description?: string; path?: string; staging?: boolean; jsonLd?: any[];
+  title?: string;
+  description?: string;
+  path?: string;
+  staging?: boolean;
+  jsonLd?: Array<Record<string, unknown>>;
 }
 const { title, description, path, staging = false, jsonLd = [] }: Props = Astro.props;
 const canonical = buildCanonical(path);
 const robotsContent = buildRobots(staging);
-const currentYear = new Date().getFullYear();
+const schemaScripts = jsonLd.map((schemaItem) => JSON.stringify(schemaItem));
+const renderSchemaScript = (schemaString: string) => (
+  <script type="application/ld+json">{schemaString}</script>
+);
 
 const navItems = [
   { href: "/", label: "Home" },
@@ -35,12 +43,17 @@ const navItems = [
     <link rel="preload" href="/fonts/Inter-Variable.woff2" as="font" type="font/woff2" crossorigin />
     <link rel="stylesheet" href={fontsHref} />
     <link rel="stylesheet" href={tailwindHref} />
-    {jsonLd.map((schema) => <script type="application/ld+json">{JSON.stringify(schema)}</script>)}
+    {schemaScripts.map(renderSchemaScript)}
     <script defer data-domain="oproepjesnederland.nl" src="https://plausible.io/js/script.js"></script>
   </head>
   <body class="flex min-h-screen flex-col bg-neutral-50 text-neutral-900">
+    <Alert18 />
     <Header title="OproepjesNederland" navItems={navItems} />
-    <main id="main-content" class="mx-auto flex w-full max-w-5xl flex-1 flex-col gap-8 px-4 py-8">
+    <main
+      id="main-content"
+      role="main"
+      class="mx-auto flex w-full max-w-5xl flex-1 flex-col gap-8 px-4 py-8"
+    >
       <slot />
     </main>
     <Footer


### PR DESCRIPTION
## Summary
- add an 18+ interstitial modal with a focus trap, keyboard-friendly controls, and persistent acknowledgement via localStorage
- embed the age gate in the base layout alongside explicit main landmarks for improved navigation
- refine button labelling to give clear aria-labels for the primary calls to action

## Testing
- npm run lint *(fails: existing lint violations in src/lib/api.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68d7e89556908324b287d44dc686ed29