### PR TITLE
Fix Pages workflow pnpm version duplication

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,15 +20,14 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      STAGING: 'true' # staging voor new.*; op productie later 'false'
+      STAGING: 'true' # staging voor new.*
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
+      # Geen versie meegeven; pnpm/action-setup leest packageManager uit package.json
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 8
 
       - name: Setup Node
         uses: actions/setup-node@v4


### PR DESCRIPTION
## Summary
- replace the Pages deployment workflow with one that relies on pnpm/action-setup to read the packageManager version
- install dependencies without a frozen lockfile before building and uploading the dist/ artifact

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d7f11a6bf88324bd56f220452bfa99