### PR TITLE
Fix Pages deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      # Geen versie meegeven; pnpm/action-setup leest packageManager uit package.json
+      # Gebruik pnpm uit packageManager in package.json; geen versienummer meegeven
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
 
@@ -33,12 +33,13 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20
-          cache: 'pnpm'
+          # BELANGRIJK: geen cache hier, voorkomt lockfile-error
+          # cache: 'pnpm'  <-- VERWIJDERD
 
       - name: Setup Pages
         uses: actions/configure-pages@v5
 
-      - name: Install deps (no frozen lockfile)
+      - name: Install dependencies
         run: pnpm install --no-frozen-lockfile
 
       - name: Build


### PR DESCRIPTION
## Summary
- replace the Pages deployment workflow to drop pnpm caching that required a lockfile
- ensure pnpm installs without frozen lockfile and builds before uploading the dist artifact

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d7f2dd3a1c8324b7b501ed5b411a51