### PR TITLE
Add handover README and align tooling scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,36 @@
+# OproepjesNederland Astro
+
+Deze site verzamelt datingoproepjes per provincie en brengt bezoekers snel naar relevante profielen.
+We bieden een lichtgewicht Astro-front-end die draait op statische hosting met minimale afhankelijkheden.
+Het doel is een overdraagbare setup die door verschillende teams eenvoudig te onderhouden is.
+
+## Quick start
+1. Gebruik Node.js 20.
+2. `pnpm install`
+3. `pnpm dev`
+4. `pnpm build`
+
+## Deploy
+- Deploy via GitHub Pages met de standaard `dist` output uit `pnpm build`.
+- Automatiseer publicatie met een GitHub Actions workflow plus een `cron` trigger voor periodieke rebuilds.
+
+## Configuratie
+Alle omgevingsafspraken leven in [`site.config.json`](./site.config.json):
+- `site`, `routing`: metadata, paden en redirects voor provincies en legacy-urls.
+- `api`: basis-URL's, limieten en deeplink-parameters voor externe datadiensten.
+- `seo` en `performance`: titels, beschrijvingen, structured data en Core Web Vitals-budgets.
+- `security`, `analytics`, `build`: CSP-verwachtingen, trackingtool en build-targets (Node 20, pnpm, outputpad, cron-schema).
+
+## SEO & performance checklijst
+- [ ] Controleer titels, meta descriptions en canonicals tegen live pagina's.
+- [ ] Valideer sitemap(s) en structured data via Search Console / Rich Results Test.
+- [ ] Meet LCP, INP en CLS met Lighthouse of WebPageTest en vergelijk met het budget.
+- [ ] Bewaak bundelgroottes (`jsKb`, `cssKb`) en optimaliseer afbeeldingen conform beleid.
+
+## Toegankelijkheid
+- Gebruik de axe-core browser-extensie om elke template-variant handmatig te scannen.
+- Log en verhelp alle kritieke en serieuze issues voordat je live gaat.
+
+## Bekende valkuilen op GitHub Pages
+- Geen custom HTTP headers; implementeer CSP via `<meta http-equiv="Content-Security-Policy">` in je templates.
+- GitHub Pages werkt alleen met statische assets: plan voor client-side fallback bij API-fouten.

--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
     "dev": "astro dev",
     "build": "astro build",
     "preview": "astro preview",
-    "lint": "eslint . --ext .ts,.tsx,.astro",
-    "format": "prettier --write ."
+    "lint": "eslint \"src/**/*.{ts,tsx,astro}\"",
+    "format": "prettier -w ."
   },
   "dependencies": {
     "astro": "^4.0.0",


### PR DESCRIPTION
## Summary
- add a transfer-ready README covering quick start, deployment, config, and checklists
- document GitHub Pages caveats and accessibility process for the team
- align lint and format npm scripts with the expected commands

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d7f3ba26248324afa3f2163e4b4ce7