### PR TITLE
Add Open Graph metadata support

### DIFF
--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -1,7 +1,7 @@
 ---
 import fontsHref from "../styles/fonts.css?url";
 import tailwindHref from "../styles/tailwind.css?url";
-import { canonical as buildCanonical, robots as buildRobots } from "../lib/seo";
+import { canonical as buildCanonical, robots as buildRobots, buildOpenGraph } from "../lib/seo";
 import Alert18 from "../components/Alert18.astro";
 
 interface Props {
@@ -10,11 +10,25 @@ interface Props {
   path?: string;
   staging?: boolean;
   jsonLd?: any[];
+  og?: {
+    title?: string;
+    description?: string;
+    image?: string;
+    type?: "website" | "article";
+    url?: string;
+  };
 }
 
-const { title, description, path, staging = false, jsonLd = [] }: Props = Astro.props;
+const { title, description, path, staging = false, jsonLd = [], og } = Astro.props as Props;
 const canonical = buildCanonical(path);
 const robotsContent = buildRobots(staging);
+// OG defaults uit helpers; vul url met canonical als niet gezet
+const ogData = buildOpenGraph({
+  title,
+  description,
+  ...(og ?? {}),
+  url: og?.url ?? canonical,
+});
 const currentYear = new Date().getFullYear();
 ---
 <!DOCTYPE html>
@@ -26,6 +40,42 @@ const currentYear = new Date().getFullYear();
     {description && <meta name="description" content={description} />}
     {canonical && <link rel="canonical" href={canonical} />}
     <meta name="robots" content={robotsContent} />
+
+    <!-- Open Graph -->
+    <meta property="og:type" content={ogData.type} />
+    {ogData.siteName && <meta property="og:site_name" content={ogData.siteName} />}
+    {ogData.title && <meta property="og:title" content={ogData.title} />}
+    {ogData.description && <meta property="og:description" content={ogData.description} />}
+    {ogData.url && <meta property="og:url" content={ogData.url} />}
+    {ogData.image && (
+      <meta
+        property="og:image"
+        content={
+          ogData.image.startsWith("http")
+            ? ogData.image
+            : canonical
+            ? new URL(ogData.image, canonical).toString()
+            : ogData.image
+        }
+      />
+    )}
+
+    <!-- Twitter -->
+    <meta name="twitter:card" content={ogData.twitterCard} />
+    {ogData.title && <meta name="twitter:title" content={ogData.title} />}
+    {ogData.description && <meta name="twitter:description" content={ogData.description} />}
+    {ogData.image && (
+      <meta
+        name="twitter:image"
+        content={
+          ogData.image.startsWith("http")
+            ? ogData.image
+            : canonical
+            ? new URL(ogData.image, canonical).toString()
+            : ogData.image
+        }
+      />
+    )}
     <link rel="preload" href="/fonts/Inter-Variable.woff2" as="font" type="font/woff2" crossorigin />
     <link rel="stylesheet" href={fontsHref} />
     <link rel="stylesheet" href={tailwindHref} />

--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -74,3 +74,26 @@ export const WEBSITE_JSONLD = jsonld("WebSite", {
     "query-input": "required name=search_term_string",
   },
 });
+
+// --- ADD: types en helper beneden in seo.ts ---
+type OGInput = {
+  title?: string;
+  description?: string;
+  image?: string; // absoluut of relatief pad
+  type?: "website" | "article";
+  url?: string; // absolute canonical URL
+};
+
+export function buildOpenGraph(input: OGInput = {}) {
+  const fallbackTitle = config.site.name;
+  const defaultImage = config.seo.openGraph?.defaultImage || "/og/default.jpg";
+  return {
+    title: input.title ?? fallbackTitle,
+    description: input.description,
+    image: input.image ?? defaultImage,
+    type: input.type ?? "website",
+    url: input.url, // Base.astro zet hier canonical in als die beschikbaar is
+    siteName: config.site.name,
+    twitterCard: "summary_large_image",
+  };
+}

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -24,6 +24,7 @@ try {
   path="/"
   staging={staging}
   jsonLd={[ORG_JSONLD, WEBSITE_JSONLD]}
+  og={{ image: "/og/default.jpg" }}
 >
   <section class="flex flex-col gap-6 rounded-2xl bg-white p-8 shadow-sm">
     <div class="flex flex-col gap-4">

--- a/src/views/PageView.astro
+++ b/src/views/PageView.astro
@@ -53,6 +53,7 @@ const itemListSchema = jsonld("ItemList", {
   path={path}
   staging={import.meta.env.STAGING}
   jsonLd={[itemListSchema]}
+  og={{ /* laat defaults werken; image valt terug op /og/default.jpg */ }}
 >
   <section class="space-y-6">
     <div class="space-y-2">


### PR DESCRIPTION
## Summary
- add an Open Graph builder helper to the SEO utilities for consistent metadata defaults
- update the Base layout to output canonical Open Graph and Twitter cards with optional overrides
- configure the home and province listing pages to opt into the new Open Graph settings

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d7f6d46fa883248ad1cd10161d8170