### PR TITLE
Simplify deeplink parameter handling

### DIFF
--- a/site.config.json
+++ b/site.config.json
@@ -29,7 +29,13 @@
     "deeplink": {
       "base": "https://chat.domein.tld/",
       "utm": { "source": "oproepjes", "medium": "referral", "campaign": "provincie-{provincie}" },
-      "subidParam": "subid"
+      "subidParam": "subid",
+      "extraParams": {
+        "refParam": "ref",
+        "refValue": "32",
+        "sourceParam": "source",
+        "subsourceParam": "subsource"
+      }
     }
   },
   "seo": {


### PR DESCRIPTION
## Summary
- replace appendUtm implementation to only manage ref, source, and subsource parameters using site name and profile id
- add configurable extraParams defaults to deeplink configuration so the new helper can read overrides

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d7fb552fec8324a23cb5d6a641648d