### PR TITLE
Add internal profile pages and update profile card links

### DIFF
--- a/src/components/ProfileCard.astro
+++ b/src/components/ProfileCard.astro
@@ -1,4 +1,6 @@
 ---
+import { slugifyName } from "../lib/slug";
+
 interface ProfileCardImage {
   src: string;
   alt: string;
@@ -54,9 +56,10 @@ const {
   age,
   province,
   img,
-  deeplink,
+  deeplink, // blijft gebruikt op detailpagina
   description,
   rank,
+  slugOverride,
 } = Astro.props as {
   id: string | number;
   name: string;
@@ -66,6 +69,7 @@ const {
   deeplink: string;
   description?: string;
   rank?: number;
+  slugOverride?: string;
 };
 
 // helper: kort en netjes afbreken rond woordgrens
@@ -82,24 +86,17 @@ const preview = description ? trim(description, 140) : "";
 const responsiveSrcset = ensureResponsiveSrcset(img.src, img.srcset);
 const responsiveSizes =
   img.sizes ?? "(min-width: 1024px) 25vw, (min-width: 768px) 33vw, 100vw";
-const analyticsProps = JSON.stringify({
-  chat_url: deeplink,
-  province,
-  rank,
-  profile_id: String(id),
-});
+const slug = slugOverride ?? slugifyName(name);
+const internalHref = `/daten-met-${slug}?id=${encodeURIComponent(String(id))}`;
 ---
 <article
   class="flex h-full flex-col overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm transition hover:border-sky-500 hover:shadow-lg"
   data-profile-id={id}
 >
   <a
-    href={deeplink}
-    aria-label={`Bekijk profiel van ${name}`}
-    rel="nofollow sponsored noopener"
+    href={internalHref}
+    aria-label={`Bekijk profiel van ${name} op OproepjesNederland`}
     class="group relative block focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-600"
-    data-analytics="outbound_click"
-    data-props={analyticsProps}
   >
     <picture
       class="block aspect-[4/3] overflow-hidden bg-slate-100"
@@ -133,12 +130,9 @@ const analyticsProps = JSON.stringify({
     )}
     <div class="mt-auto">
       <a
-        href={deeplink}
-        aria-label={`Start gesprek met ${name}`}
-        rel="nofollow sponsored noopener"
+        href={internalHref}
+        aria-label={`Bekijk profiel van ${name} op OproepjesNederland`}
         class="inline-flex items-center justify-center rounded-full bg-sky-600 px-4 py-2 text-sm font-semibold text-white transition hover:bg-sky-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-400"
-        data-analytics="outbound_click"
-        data-props={analyticsProps}
       >
         Profiel bekijken
       </a>

--- a/src/lib/slug.ts
+++ b/src/lib/slug.ts
@@ -1,0 +1,8 @@
+export function slugifyName(name: string) {
+  return name
+    .toLowerCase()
+    .normalize("NFD")
+    .replace(/\p{Diacritic}/gu, "")
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/(^-|-$)/g, "");
+}

--- a/src/pages/daten-met-[slug]/index.astro
+++ b/src/pages/daten-met-[slug]/index.astro
@@ -1,0 +1,92 @@
+---
+import Base from "../../layouts/Base.astro";
+import { config } from "../../lib/config";
+import { getProvince } from "../../lib/api";
+import { PROVINCES } from "../../lib/provinces";
+import { slugifyName } from "../../lib/slug";
+
+type CardProfile = Awaited<ReturnType<typeof getProvince>>["profiles"][number];
+
+export async function getStaticPaths() {
+  const pageSize = config.api.limits?.pageSize ?? 60;
+  const paths: Array<{ params: { slug: string }; props: { profile: CardProfile } }> = [];
+
+  for (const provinceName of PROVINCES) {
+    const first = await getProvince(provinceName, pageSize, 1);
+    const totalPages = first.totalPages ?? 1;
+
+    const collect = async (page: number) => {
+      const data = page === 1 ? first : await getProvince(provinceName, pageSize, page);
+      for (const p of data.profiles) {
+        const slug = slugifyName(p.name);
+        paths.push({ params: { slug }, props: { profile: p } });
+      }
+    };
+
+    for (let page = 1; page <= totalPages; page++) {
+      await collect(page);
+    }
+  }
+
+  return paths;
+}
+
+const { profile } = Astro.props as { profile: CardProfile };
+
+// Query-id valideren (optioneel maar veilig)
+const q = new URL(Astro.url).searchParams;
+const idParam = q.get("id");
+if (!idParam || String(idParam) !== String(profile.id)) {
+  return Astro.redirect("/404.html");
+}
+
+// SEO
+const title = `Date met ${profile.name} in ${profile.province}`;
+const description = profile.description ?? `Leer ${profile.name} kennen en stuur gratis een bericht.`;
+const path = Astro.url.pathname + Astro.url.search;
+
+// Afbeelding (fallback aanwezig)
+const imgSrc = profile.img?.src ?? "/img/fallback.svg";
+const imgAlt = profile.img?.alt ?? profile.name;
+
+// JSON-LD minimaal
+const personLd = { "@type": "Person", name: profile.name, description: profile.description ?? undefined };
+---
+<Base title={title} description={description} path={path} staging={import.meta.env.STAGING} jsonLd={[personLd]}>
+  <article class="mx-auto grid max-w-5xl grid-cols-1 gap-8 md:grid-cols-[320px,1fr]">
+    <div class="overflow-hidden rounded-2xl border border-neutral-200 bg-white">
+      <img
+        src={imgSrc}
+        alt={imgAlt}
+        loading="eager"
+        decoding="async"
+        onerror="this.src='/img/fallback.svg'"
+        class="block h-auto w-full object-cover"
+      />
+    </div>
+
+    <div class="space-y-4">
+      <header>
+        <h1 class="text-3xl font-bold text-neutral-900">{profile.name}</h1>
+        <p class="text-neutral-700">{profile.age} jaar · {profile.province}</p>
+      </header>
+
+      {profile.description && (
+        <p class="text-neutral-800 leading-relaxed">{profile.description}</p>
+      )}
+
+      <div class="pt-2">
+        <a
+          href={profile.deeplink}
+          rel="nofollow sponsored noopener"
+          target="_blank"
+          class="inline-flex items-center justify-center rounded-full bg-sky-600 px-6 py-3 text-base font-semibold text-white transition hover:bg-sky-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-400"
+          aria-label="Stuur gratis bericht"
+          data-analytics="outbound_click"
+        >
+          Stuur gratis bericht
+        </a>
+      </div>
+    </div>
+  </article>
+</Base>


### PR DESCRIPTION
## Summary
- add a reusable slugify helper for generating profile path segments
- create a statically generated profile detail route that validates the ?id= query and renders deeplink CTA
- point profile cards to the internal detail URLs so list views link to the new pages

## Testing
- npm run build *(fails to reach external API endpoints in CI-less container; build completes locally with logged ENETUNREACH errors)*

------
https://chatgpt.com/codex/tasks/task_e_68d93efd476483248c476a3d765cd73b