### PR TITLE
Fix static profile detail generation

### DIFF
--- a/src/pages/daten-met-[slug]/index.astro
+++ b/src/pages/daten-met-[slug]/index.astro
@@ -1,4 +1,3 @@
----
 import Base from "../../layouts/Base.astro";
 import { config } from "../../lib/config";
 import { getProvince } from "../../lib/api";
@@ -9,8 +8,9 @@ type CardProfile = Awaited<ReturnType<typeof getProvince>>["profiles"][number];
 
 export async function getStaticPaths() {
   const pageSize = config.api.limits?.pageSize ?? 60;
-  const paths: Array<{ params: { slug: string }; props: { profile: CardProfile } }> = [];
+  const paths: Array<{ params: { slug: string }, props: { profile: CardProfile } }> = [];
 
+  // Verzamel ALLE profielen die we toch al tijdens build kunnen ophalen
   for (const provinceName of PROVINCES) {
     const first = await getProvince(provinceName, pageSize, 1);
     const totalPages = first.totalPages ?? 1;
@@ -19,6 +19,7 @@ export async function getStaticPaths() {
       const data = page === 1 ? first : await getProvince(provinceName, pageSize, page);
       for (const p of data.profiles) {
         const slug = slugifyName(p.name);
+        // Let op: slug-collisies komen zelden voor; als het gebeurt, renderen we de laatst ingezamelde.
         paths.push({ params: { slug }, props: { profile: p } });
       }
     };
@@ -33,26 +34,24 @@ export async function getStaticPaths() {
 
 const { profile } = Astro.props as { profile: CardProfile };
 
-// Query-id valideren (optioneel maar veilig)
+// Geen harde redirect meer op query-id mismatch.
+// We lezen de query alleen om de canonical te verrijken (optioneel).
 const q = new URL(Astro.url).searchParams;
-const idParam = q.get("id");
-if (!idParam || String(idParam) !== String(profile.id)) {
-  return Astro.redirect("/404.html");
-}
+const idParam = q.get("id") ?? String(profile.id);
 
 // SEO
 const title = `Date met ${profile.name} in ${profile.province}`;
 const description = profile.description ?? `Leer ${profile.name} kennen en stuur gratis een bericht.`;
-const path = Astro.url.pathname + Astro.url.search;
+const canonicalPath = `${Astro.url.pathname}?id=${encodeURIComponent(String(idParam))}`;
 
-// Afbeelding (fallback aanwezig)
+// Afbeelding + fallback
 const imgSrc = profile.img?.src ?? "/img/fallback.svg";
 const imgAlt = profile.img?.alt ?? profile.name;
 
-// JSON-LD minimaal
+// JSON-LD minimaal, veilig
 const personLd = { "@type": "Person", name: profile.name, description: profile.description ?? undefined };
 ---
-<Base title={title} description={description} path={path} staging={import.meta.env.STAGING} jsonLd={[personLd]}>
+<Base title={title} description={description} path={canonicalPath} staging={import.meta.env.STAGING} jsonLd={[personLd]}>
   <article class="mx-auto grid max-w-5xl grid-cols-1 gap-8 md:grid-cols-[320px,1fr]">
     <div class="overflow-hidden rounded-2xl border border-neutral-200 bg-white">
       <img


### PR DESCRIPTION
## Summary
- generate static profile detail pages during build by collecting all province profiles
- remove strict query id enforcement while preserving canonical URL enrichment and CTA deeplink

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d94d56c7048324a72d5d4927bacb9e