### PR TITLE
Add city details to profile data and UI

### DIFF
--- a/src/components/ProfileCard.astro
+++ b/src/components/ProfileCard.astro
@@ -117,7 +117,13 @@ const internalHref = `/daten-met-${slug}?id=${encodeURIComponent(String(id))}`;
   <div class="flex flex-1 flex-col gap-4 p-6 text-slate-900">
     <div>
       <h3 class="text-xl font-semibold text-slate-900">{name}</h3>
-      <p class="text-sm text-slate-700">{age} jaar &middot; {province}</p>
+      {/*
+        Toon stad als die bekend is; anders val terug op provincie
+      */}
+
+      <p class="text-sm text-slate-700">
+        {age} jaar{(Astro.props as any).city ? ` · ${(Astro.props as any).city}` : ` · ${province}`}
+      </p>
     </div>
     {preview && (
       <p

--- a/src/pages/daten-met-[slug]/index.astro
+++ b/src/pages/daten-met-[slug]/index.astro
@@ -76,6 +76,39 @@ const personLd = { "@type": "Person", name: profile.name, description: profile.d
         <p class="text-neutral-800 leading-relaxed">{profile.description}</p>
       )}
 
+      <section class="mt-2 grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
+        <div class="rounded-xl border border-neutral-200 bg-white p-4">
+          <p class="text-xs uppercase tracking-wide text-neutral-500">Provincie</p>
+          <p class="mt-1 font-medium text-neutral-900">{profile.province}</p>
+        </div>
+
+        {profile.city && (
+          <div class="rounded-xl border border-neutral-200 bg-white p-4">
+            <p class="text-xs uppercase tracking-wide text-neutral-500">Stad</p>
+            <p class="mt-1 font-medium text-neutral-900">{profile.city}</p>
+          </div>
+        )}
+
+        <div class="rounded-xl border border-neutral-200 bg-white p-4">
+          <p class="text-xs uppercase tracking-wide text-neutral-500">Leeftijd</p>
+          <p class="mt-1 font-medium text-neutral-900">{profile.age}</p>
+        </div>
+
+        {profile.relationship && (
+          <div class="rounded-xl border border-neutral-200 bg-white p-4">
+            <p class="text-xs uppercase tracking-wide text-neutral-500">Relatiestatus</p>
+            <p class="mt-1 font-medium text-neutral-900">{profile.relationship}</p>
+          </div>
+        )}
+
+        {profile.height && (
+          <div class="rounded-xl border border-neutral-200 bg-white p-4">
+            <p class="text-xs uppercase tracking-wide text-neutral-500">Lengte</p>
+            <p class="mt-1 font-medium text-neutral-900">{profile.height}</p>
+          </div>
+        )}
+      </section>
+
       <div class="pt-2">
         <a
           href={profile.deeplink}


### PR DESCRIPTION
## Summary
- extend the Profile model with optional city, relationship, height, and richer description fallback mapping
- update profile cards to show the city when available, with a province fallback
- render a personal information grid on the dating detail page with province, city, age, relationship, and height

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d952fd44248324b21c9a1761468164