### PR TITLE
Add dating tips overview and city templates

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -3,8 +3,9 @@ import { PROVINCES, provinceToSlug } from "../lib/provinces";
 
 const datingTips = [
   { href: "/datingtips/veilig-daten/", label: "Veilig daten (18+)" },
-  { href: "/datingtips/eerste-bericht/", label: "Het eerste bericht" },
-  { href: "/datingtips/afspreken/", label: "Afspreken: do’s & don’ts" },
+  { href: "/datingtips/het-eerste-bericht/", label: "Het eerste bericht" },
+  { href: "/datingtips/dos-en-donts-online/", label: "Do’s & don’ts online" },
+  { href: "/datingtips-nederland/", label: "Alle steden" },
 ];
 
 const socials = [

--- a/src/lib/cities.ts
+++ b/src/lib/cities.ts
@@ -1,0 +1,68 @@
+export type CityItem = { city: string; slug: string; province: string };
+
+export const CITIES: CityItem[] = [
+
+{ city: "Amsterdam", slug: "amsterdam", province: "Noord-Holland" },
+
+{ city: "Rotterdam", slug: "rotterdam", province: "Zuid-Holland" },
+
+{ city: "Den Haag", slug: "den-haag", province: "Zuid-Holland" },
+
+{ city: "Utrecht", slug: "utrecht", province: "Utrecht" },
+
+{ city: "Eindhoven", slug: "eindhoven", province: "Noord-Brabant" },
+
+{ city: "Groningen", slug: "groningen", province: "Groningen" },
+
+{ city: "Tilburg", slug: "tilburg", province: "Noord-Brabant" },
+
+{ city: "Almere", slug: "almere", province: "Flevoland" },
+
+{ city: "Breda", slug: "breda", province: "Noord-Brabant" },
+
+{ city: "Nijmegen", slug: "nijmegen", province: "Gelderland" },
+
+{ city: "Apeldoorn", slug: "apeldoorn", province: "Gelderland" },
+
+{ city: "Haarlem", slug: "haarlem", province: "Noord-Holland" },
+
+{ city: "Arnhem", slug: "arnhem", province: "Gelderland" },
+
+{ city: "Haarlemmermeer", slug: "haarlemmermeer", province: "Noord-Holland" },
+
+{ city: "Amersfoort", slug: "amersfoort", province: "Utrecht" },
+
+{ city: "Enschede", slug: "enschede", province: "Overijssel" },
+
+{ city: "Zaanstad", slug: "zaanstad", province: "Noord-Holland" },
+
+{ city: "’s-Hertogenbosch", slug: "s-hertogenbosch", province: "Noord-Brabant" },
+
+{ city: "Zwolle", slug: "zwolle", province: "Overijssel" },
+
+{ city: "Leiden", slug: "leiden", province: "Zuid-Holland" },
+
+{ city: "Leeuwarden", slug: "leeuwarden", province: "Friesland" },
+
+{ city: "Zoetermeer", slug: "zoetermeer", province: "Zuid-Holland" },
+
+{ city: "Maastricht", slug: "maastricht", province: "Limburg" },
+
+{ city: "Ede", slug: "ede", province: "Gelderland" },
+
+{ city: "Dordrecht", slug: "dordrecht", province: "Zuid-Holland" },
+
+{ city: "Westland", slug: "westland", province: "Zuid-Holland" },
+
+{ city: "Alphen aan den Rijn", slug: "alphen-aan-den-rijn", province: "Zuid-Holland" },
+
+{ city: "Alkmaar", slug: "alkmaar", province: "Noord-Holland" },
+
+{ city: "Delft", slug: "delft", province: "Zuid-Holland" },
+
+{ city: "Emmen", slug: "emmen", province: "Drenthe" },
+
+{ city: "Venlo", slug: "venlo", province: "Limburg" },
+
+{ city: "Deventer", slug: "deventer", province: "Overijssel" },
+];

--- a/src/pages/datingtips-nederland/index.astro
+++ b/src/pages/datingtips-nederland/index.astro
@@ -1,70 +1,37 @@
 ---
-// src/pages/datingtips-nederland/index.astro
 import Base from "../../layouts/Base.astro";
-import { jsonld } from "../../lib/seo";
+import { CITIES } from "../../lib/cities";
 
-// (Later uitbreidbaar)
-const TIPS = [
-  {
-    title: "Veilig daten (18+)",
-    href: "/datingtips/veilig-daten/",
-    description: "Praktische veiligheidsrichtlijnen voor verantwoord daten.",
-  },
-  {
-    title: "Het eerste bericht",
-    href: "/datingtips/het-eerste-bericht/",
-    description: "Zo schrijf je een leuk, oprecht én effectief openingsbericht.",
-  },
-  {
-    title: "Afspreken: do’s & don’ts",
-    href: "/datingtips/afspreken-dos-donts/",
-    description: "Checklist voor je eerste (en volgende) date.",
-  },
-];
-
-// SEO
-const title = "Datingtips in Nederland | OproepjesNederland";
-const description = "Overzicht van onze belangrijkste datingtips voor 18+ bezoekers.";
-const path = "/datingtips-nederland/";
-
-// JSON-LD ItemList
-const itemList = jsonld("ItemList", {
-  name: "Datingtips overzicht",
-  itemListElement: TIPS.map((tip, i) => ({
-    "@type": "ListItem",
-    position: i + 1,
-    name: tip.title,
-    url: tip.href,
-    description: tip.description,
-  })),
-});
+const title = "Datingtips voor Nederland – algemeen & per stad";
+const description = "Lees onze algemene datingtips en ontdek praktische tips per stad. Start veilig en slim met daten (18+).";
 ---
-<Base title={title} description={description} path={path} staging={import.meta.env.STAGING} jsonLd={[itemList]}>
-  <section class="mx-auto max-w-5xl space-y-6">
-    <div class="space-y-2">
-      <h1 class="text-3xl font-bold text-neutral-900">Datingtips in Nederland</h1>
-      <p class="text-neutral-700">
-        Leer slimmer, veiliger en leuker daten met onze praktische 18+ tips.
-      </p>
-    </div>
+<Base title={title} description={description} path={Astro.url.pathname} staging={import.meta.env.STAGING}>
 
-    <div class="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
-      {TIPS.map((tip) => (
-        <a
-          href={tip.href}
-          class="group flex h-full flex-col justify-between rounded-xl border border-neutral-200 bg-white p-5 shadow-sm transition hover:border-accent hover:shadow focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent"
-          aria-label={`Lees: ${tip.title}`}
-        >
-          <div class="space-y-2">
-            <h2 class="text-lg font-semibold text-neutral-900 group-hover:text-accent">{tip.title}</h2>
-            <p class="text-sm text-neutral-700">{tip.description}</p>
-          </div>
-          <span class="mt-4 inline-flex items-center gap-2 text-sm font-semibold text-accent">
-            Lees tip
-            <span aria-hidden="true">→</span>
-          </span>
-        </a>
-      ))}
-    </div>
-  </section>
+<header class="mb-6">
+<h1 class="text-3xl font-bold text-neutral-900">Datingtips in Nederland</h1>
+<p class="text-neutral-700">Algemene gidsen én tips per stad. Later vullen we deze pagina’s met uitgebreidere content.</p>
+</header>
+<section class="space-y-3">
+<h2 class="text-xl font-semibold">Algemene tips</h2>
+<ul class="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
+ <li><a class="block rounded-xl border border-neutral-200 bg-white p-4 hover:border-sky-500" href="/datingtips/veilig-daten/">Veilig daten (18+)</a></li>
+
+ <li><a class="block rounded-xl border border-neutral-200 bg-white p-4 hover:border-sky-500" href="/datingtips/het-eerste-bericht/">Het eerste bericht</a></li>
+
+ <li><a class="block rounded-xl border border-neutral-200 bg-white p-4 hover:border-sky-500" href="/datingtips/dos-en-donts-online/">Do’s & don’ts online</a></li>
+
+</ul>
+</section>
+<section class="mt-8 space-y-3">
+<h2 class="text-xl font-semibold">Tips per stad</h2>
+<ul class="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-4">
+ {CITIES.map((c) => (
+
+   <li><a class="block rounded-xl border border-neutral-200 bg-white p-4 hover:border-sky-500" href={`/datingtips/${c.slug}/`}>Datingtips {c.city}</a></li>
+
+ ))}
+
+</ul>
+</section>
+
 </Base>

--- a/src/pages/datingtips/[city]/index.astro
+++ b/src/pages/datingtips/[city]/index.astro
@@ -1,0 +1,69 @@
+---
+import Base from "../../../layouts/Base.astro";
+import ProfileCard from "../../../components/ProfileCard.astro";
+import { CITIES } from "../../../lib/cities";
+import { getProvince } from "../../../lib/api";
+
+type CardProfile = Awaited<ReturnType<typeof getProvince>>["profiles"][number];
+
+export async function getStaticPaths() {
+
+const paths: { params: { city: string }; props: { city: string; province: string; profiles: CardProfile[] } }[] = [];
+
+for (const c of CITIES) {
+
+// haal max 60 uit provincie; filter op citynaam; fallback op provincie als er < 6 matches zijn
+
+let all: CardProfile[] = [];
+
+try {
+
+const data = await getProvince(c.province, 60, 1);
+
+all = data.profiles ?? [];
+
+} catch (error) {
+
+all = [];
+
+}
+
+const matches = all.filter((p) => (p.city ?? "").toLowerCase() === c.city.toLowerCase());
+
+const pick = (matches.length >= 6 ? matches : all).slice(0, 6);
+
+paths.push({ params: { city: c.slug }, props: { city: c.city, province: c.province, profiles: pick } });
+
+}
+
+return paths;
+}
+
+const { city, province, profiles } = Astro.props as { city: string; province: string; profiles: CardProfile[] };
+const title = `Datingtips ${city} – slim daten in ${city}`;
+const description = `Handige datingtips voor ${city}. Lees de basis en bekijk voorbeelden van profielen uit ${province}.`;
+---
+<Base title={title} description={description} path={Astro.url.pathname} staging={import.meta.env.STAGING}>
+
+<header class="mb-6">
+<h1 class="text-3xl font-bold text-neutral-900">Datingtips {city}</h1>
+<p class="text-neutral-700">Hier volgt later uitgebreide content over daten in {city}. Ondertussen alvast een paar profielen uit {province}.</p>
+</header>
+
+{profiles.length > 0 ? (
+
+<section class="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+ {profiles.map((p, idx) => (
+
+   <ProfileCard {...p} rank={idx + 1} />
+
+ ))}
+
+</section>
+
+) : (
+
+<p class="text-neutral-700">Er zijn op dit moment geen profielen beschikbaar uit {province}.</p>
+
+)}
+</Base>

--- a/src/pages/datingtips/dos-en-donts-online/index.astro
+++ b/src/pages/datingtips/dos-en-donts-online/index.astro
@@ -1,0 +1,11 @@
+---
+import Base from "../../../layouts/Base.astro";
+const title = "Do’s & don’ts online – slim en respectvol daten";
+const description = "Wat werkt wél en wat juist niet? Checklist met do’s & don’ts. Content volgt.";
+---
+<Base title={title} description={description} path={Astro.url.pathname} staging={import.meta.env.STAGING}>
+
+<h1 class="text-3xl font-bold text-neutral-900 mb-4">Do’s & don’ts online</h1>
+<p class="text-neutral-700">Placeholder voor content. Hier komt een compacte checklist met concrete do’s en don’ts.</p>
+
+</Base>

--- a/src/pages/datingtips/het-eerste-bericht/index.astro
+++ b/src/pages/datingtips/het-eerste-bericht/index.astro
@@ -1,0 +1,11 @@
+---
+import Base from "../../../layouts/Base.astro";
+const title = "Het eerste bericht – zo maak je een goed begin";
+const description = "Praktische openingstips die werken. Voorbeelden en veelgemaakte fouten. Content volgt.";
+---
+<Base title={title} description={description} path={Astro.url.pathname} staging={import.meta.env.STAGING}>
+
+<h1 class="text-3xl font-bold text-neutral-900 mb-4">Het eerste bericht</h1>
+<p class="text-neutral-700">Placeholder voor content. Hier plaatsen we straks sjablonen en voorbeelden voor je eerste bericht.</p>
+
+</Base>

--- a/src/pages/datingtips/veilig-daten/index.astro
+++ b/src/pages/datingtips/veilig-daten/index.astro
@@ -1,0 +1,11 @@
+---
+import Base from "../../../layouts/Base.astro";
+const title = "Veilig daten (18+) – tips & aandachtspunten";
+const description = "Leer hoe je veilig online en offline date. Korte checklist en do’s & don’ts. Later vullen we deze gids verder.";
+---
+<Base title={title} description={description} path={Astro.url.pathname} staging={import.meta.env.STAGING}>
+
+<h1 class="text-3xl font-bold text-neutral-900 mb-4">Veilig daten (18+)</h1>
+<p class="text-neutral-700">Placeholder voor content. Hier komt de volledige gids met concrete, veilige stappen en voorbeelden.</p>
+
+</Base>

--- a/src/pages/sitemap.xml.ts
+++ b/src/pages/sitemap.xml.ts
@@ -2,6 +2,7 @@ import type { APIRoute } from "astro";
 import { config } from "../lib/config";
 import { PROVINCES, provinceToSlug } from "../lib/provinces";
 import { getProvince } from "../lib/api";
+import { CITIES } from "../lib/cities";
 
 export const prerender = true;
 
@@ -26,6 +27,10 @@ export const GET: APIRoute = async () => {
   const urls: Array<{ loc: string; priority: string }> = [
     { loc: absoluteUrl(baseUrl, "/"), priority: HOME_PRIORITY },
     { loc: absoluteUrl(baseUrl, "/dating-nederland/"), priority: PROVINCE_PRIORITY },
+    { loc: absoluteUrl(baseUrl, "/datingtips-nederland/"), priority: PROVINCE_PRIORITY },
+    { loc: absoluteUrl(baseUrl, "/datingtips/veilig-daten/"), priority: PROVINCE_PRIORITY },
+    { loc: absoluteUrl(baseUrl, "/datingtips/het-eerste-bericht/"), priority: PROVINCE_PRIORITY },
+    { loc: absoluteUrl(baseUrl, "/datingtips/dos-en-donts-online/"), priority: PROVINCE_PRIORITY },
   ];
 
   const provinceEntries = await Promise.all(
@@ -45,6 +50,12 @@ export const GET: APIRoute = async () => {
       const pagePath = `${basePath}page/${page}/`;
       urls.push({ loc: absoluteUrl(baseUrl, pagePath), priority: PAGINATED_PRIORITY });
     }
+  }
+
+  // Datingtips per stad
+  for (const city of CITIES) {
+    const cityPath = `/datingtips/${city.slug}/`;
+    urls.push({ loc: absoluteUrl(baseUrl, cityPath), priority: PROVINCE_PRIORITY });
   }
 
   const body = `<?xml version="1.0" encoding="UTF-8"?>\n` +


### PR DESCRIPTION
## Summary
- add reusable city metadata mapping for Dutch dating tips
- build out dating tips overview, general tip placeholders, and per-city route with profile cards
- surface new pages through the header navigation and sitemap

## Testing
- npm run build


------
https://chatgpt.com/codex/tasks/task_e_68db518d29ac8324a77612f54052326f