### PR TITLE
Add datingtips content collection and content routing

### DIFF
--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -1,0 +1,26 @@
+import { defineCollection, z } from "astro:content";
+
+const tipSchema = z.object({
+  title: z.string(),
+  type: z.enum(["general","city"]),
+  slug: z.string().optional(),
+  metaDescription: z.string().min(120).max(180),
+  intro: z.string().min(100), // we valideren globaal; niet hard op 250
+  city: z.string().optional(),
+  province: z.string().optional(),
+  profiles: z.object({
+    source: z.enum(["popular","province"]),
+    limit: z.number().min(3).max(24).default(9),
+  }).default({ source: "popular", limit: 9 }),
+  cta: z.object({
+    label: z.string(),
+    href: z.string(), // mag intern pad zijn
+  }),
+});
+
+const datingtips = defineCollection({
+  type: "content",
+  schema: tipSchema,
+});
+
+export const collections = { datingtips };

--- a/src/pages/datingtips-nederland/index.astro
+++ b/src/pages/datingtips-nederland/index.astro
@@ -1,9 +1,31 @@
 ---
 import Base from "../../layouts/Base.astro";
 import { CITIES } from "../../lib/cities";
+import { getCollection } from "astro:content";
 
 const title = "Datingtips voor Nederland – algemeen & per stad";
 const description = "Lees onze algemene datingtips en ontdek praktische tips per stad. Start veilig en slim met daten (18+).";
+const tips = await getCollection("datingtips");
+
+const findTipForHref = (href: string) => {
+  const normalized = href.replace(/^\/+|\/+$/g, "");
+  const segments = normalized.split("/");
+  const slug = segments[segments.length - 1];
+  const routeSlug = normalized.replace(/\//g, "-");
+
+  return tips.find((tip) => {
+    const matchesSlug = [slug, routeSlug].some((candidate) =>
+      candidate ? tip.slug === candidate : false,
+    );
+    const matchesId = [slug, routeSlug].some((candidate) =>
+      candidate
+        ? tip.id === candidate || tip.id.endsWith(`/${candidate}`)
+        : false,
+    );
+
+    return matchesSlug || matchesId;
+  });
+};
 ---
 <Base title={title} description={description} path={Astro.url.pathname} staging={import.meta.env.STAGING}>
 
@@ -14,22 +36,90 @@ const description = "Lees onze algemene datingtips en ontdek praktische tips per
 <section class="space-y-3">
 <h2 class="text-xl font-semibold">Algemene tips</h2>
 <ul class="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
- <li><a class="block rounded-xl border border-neutral-200 bg-white p-4 hover:border-sky-500" href="/datingtips/veilig-daten/">Veilig daten (18+)</a></li>
+ <li>
+   {(() => {
+     const href = "/datingtips/veilig-daten/";
+     const tip = findTipForHref(href);
+     return (
+       <a class="block rounded-xl border border-neutral-200 bg-white p-4 hover:border-sky-500" href={href}>
+         <span class="block font-semibold text-neutral-900">Veilig daten (18+)</span>
+         {tip && (
+           <span
+             class="mt-2 block text-sm text-neutral-600"
+             style="display:-webkit-box;-webkit-line-clamp:3;-webkit-box-orient:vertical;overflow:hidden;"
+           >
+             {tip.data.metaDescription}
+           </span>
+         )}
+       </a>
+     );
+   })()}
+ </li>
 
- <li><a class="block rounded-xl border border-neutral-200 bg-white p-4 hover:border-sky-500" href="/datingtips/het-eerste-bericht/">Het eerste bericht</a></li>
+ <li>
+   {(() => {
+     const href = "/datingtips/het-eerste-bericht/";
+     const tip = findTipForHref(href);
+     return (
+       <a class="block rounded-xl border border-neutral-200 bg-white p-4 hover:border-sky-500" href={href}>
+         <span class="block font-semibold text-neutral-900">Het eerste bericht</span>
+         {tip && (
+           <span
+             class="mt-2 block text-sm text-neutral-600"
+             style="display:-webkit-box;-webkit-line-clamp:3;-webkit-box-orient:vertical;overflow:hidden;"
+           >
+             {tip.data.metaDescription}
+           </span>
+         )}
+       </a>
+     );
+   })()}
+ </li>
 
- <li><a class="block rounded-xl border border-neutral-200 bg-white p-4 hover:border-sky-500" href="/datingtips/dos-en-donts-online/">Do’s & don’ts online</a></li>
+ <li>
+   {(() => {
+     const href = "/datingtips/dos-en-donts-online/";
+     const tip = findTipForHref(href);
+     return (
+       <a class="block rounded-xl border border-neutral-200 bg-white p-4 hover:border-sky-500" href={href}>
+         <span class="block font-semibold text-neutral-900">Do’s & don’ts online</span>
+         {tip && (
+           <span
+             class="mt-2 block text-sm text-neutral-600"
+             style="display:-webkit-box;-webkit-line-clamp:3;-webkit-box-orient:vertical;overflow:hidden;"
+           >
+             {tip.data.metaDescription}
+           </span>
+         )}
+       </a>
+     );
+   })()}
+ </li>
 
 </ul>
 </section>
 <section class="mt-8 space-y-3">
 <h2 class="text-xl font-semibold">Tips per stad</h2>
 <ul class="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-4">
- {CITIES.map((c) => (
-
-   <li><a class="block rounded-xl border border-neutral-200 bg-white p-4 hover:border-sky-500" href={`/datingtips/${c.slug}/`}>Datingtips {c.city}</a></li>
-
- ))}
+ {CITIES.map((c) => {
+   const href = `/datingtips/${c.slug}/`;
+   const tip = findTipForHref(href);
+   return (
+     <li>
+       <a class="block rounded-xl border border-neutral-200 bg-white p-4 hover:border-sky-500" href={href}>
+         <span class="block font-semibold text-neutral-900">Datingtips {c.city}</span>
+         {tip && (
+           <span
+             class="mt-2 block text-sm text-neutral-600"
+             style="display:-webkit-box;-webkit-line-clamp:3;-webkit-box-orient:vertical;overflow:hidden;"
+           >
+             {tip.data.metaDescription}
+           </span>
+         )}
+       </a>
+     </li>
+   );
+ })}
 
 </ul>
 </section>

--- a/src/pages/datingtips/[city]/index.astro
+++ b/src/pages/datingtips/[city]/index.astro
@@ -1,69 +1,136 @@
 ---
 import Base from "../../../layouts/Base.astro";
 import ProfileCard from "../../../components/ProfileCard.astro";
+import CTA from "../../../components/CTA.astro";
 import { CITIES } from "../../../lib/cities";
-import { getProvince } from "../../../lib/api";
+import { getProvince, getPopular } from "../../../lib/api";
+import { getCollection, getEntry } from "astro:content";
 
 type CardProfile = Awaited<ReturnType<typeof getProvince>>["profiles"][number];
 
+type StaticPath = {
+  params: { city: string };
+  props: { city: string; province: string; profiles: CardProfile[] };
+};
+
 export async function getStaticPaths() {
+  const paths: StaticPath[] = [];
 
-const paths: { params: { city: string }; props: { city: string; province: string; profiles: CardProfile[] } }[] = [];
+  for (const c of CITIES) {
+    let all: CardProfile[] = [];
 
-for (const c of CITIES) {
+    try {
+      const data = await getProvince(c.province, 60, 1);
+      all = data.profiles ?? [];
+    } catch (error) {
+      all = [];
+    }
 
-// haal max 60 uit provincie; filter op citynaam; fallback op provincie als er < 6 matches zijn
+    const matches = all.filter((p) => (p.city ?? "").toLowerCase() === c.city.toLowerCase());
+    const pick = (matches.length >= 6 ? matches : all).slice(0, 6);
 
-let all: CardProfile[] = [];
+    paths.push({ params: { city: c.slug }, props: { city: c.city, province: c.province, profiles: pick } });
+  }
 
-try {
-
-const data = await getProvince(c.province, 60, 1);
-
-all = data.profiles ?? [];
-
-} catch (error) {
-
-all = [];
-
-}
-
-const matches = all.filter((p) => (p.city ?? "").toLowerCase() === c.city.toLowerCase());
-
-const pick = (matches.length >= 6 ? matches : all).slice(0, 6);
-
-paths.push({ params: { city: c.slug }, props: { city: c.city, province: c.province, profiles: pick } });
-
-}
-
-return paths;
+  return paths;
 }
 
 const { city, province, profiles } = Astro.props as { city: string; province: string; profiles: CardProfile[] };
-const title = `Datingtips ${city} – slim daten in ${city}`;
-const description = `Handige datingtips voor ${city}. Lees de basis en bekijk voorbeelden van profielen uit ${province}.`;
+const citySlug = Astro.params.city ?? "";
+const routeSlug = `datingtips-${citySlug}`;
+const collection = await getCollection("datingtips");
+type DatingTipEntry = (typeof collection)[number];
+
+const matchBySlug = (entry: DatingTipEntry, candidate: string) =>
+  candidate
+    ? entry.slug === candidate || entry.id === candidate || entry.id.endsWith(`/${candidate}`)
+    : false;
+
+let matched = collection.find((entry) => matchBySlug(entry, routeSlug) || matchBySlug(entry, citySlug));
+
+if (!matched) {
+  matched = collection.find((entry) => entry.data.city?.toLowerCase() === city.toLowerCase());
+}
+
+let Content: Awaited<ReturnType<DatingTipEntry["render"]>>["Content"] | undefined;
+let contentTitle = `Datingtips ${city} – slim daten in ${city}`;
+let contentDescription = `Handige datingtips voor ${city}. Lees de basis en bekijk voorbeelden van profielen uit ${province}.`;
+let intro: string | undefined;
+let pageProfiles: CardProfile[] = profiles;
+let cta: { label: string; href: string } | undefined;
+
+if (matched) {
+  const entry = await getEntry("datingtips", matched.id);
+  const rendered = await entry.render();
+  Content = rendered.Content;
+
+  contentTitle = entry.data.title;
+  contentDescription = entry.data.metaDescription;
+  intro = entry.data.intro;
+  cta = entry.data.cta;
+
+  try {
+    if (entry.data.profiles.source === "province" && entry.data.province) {
+      const provinceData = await getProvince(entry.data.province, entry.data.profiles.limit, 1);
+      pageProfiles = provinceData.profiles ?? [];
+    } else {
+      const popularData = await getPopular(entry.data.profiles.limit);
+      pageProfiles = popularData ?? [];
+    }
+  } catch (error) {
+    pageProfiles = [];
+  }
+}
 ---
-<Base title={title} description={description} path={Astro.url.pathname} staging={import.meta.env.STAGING}>
+<Base title={contentTitle} description={contentDescription} path={Astro.url.pathname} staging={import.meta.env.STAGING}>
+  {matched && Content ? (
+    <>
+      <header class="mb-8 space-y-4">
+        <h1 class="text-3xl font-bold text-neutral-900">{contentTitle}</h1>
+        {intro && <p class="text-neutral-700">{intro}</p>}
+      </header>
 
-<header class="mb-6">
-<h1 class="text-3xl font-bold text-neutral-900">Datingtips {city}</h1>
-<p class="text-neutral-700">Hier volgt later uitgebreide content over daten in {city}. Ondertussen alvast een paar profielen uit {province}.</p>
-</header>
+      <article class="prose max-w-none prose-p:text-neutral-800 prose-headings:text-neutral-900">
+        <Content />
+      </article>
 
-{profiles.length > 0 ? (
+      <section class="mt-10 space-y-4">
+        <h2 class="text-2xl font-semibold text-neutral-900">Voorbeeldprofielen</h2>
+        {pageProfiles.length > 0 ? (
+          <div class="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+            {pageProfiles.map((p, idx) => (
+              <ProfileCard {...p} rank={idx + 1} />
+            ))}
+          </div>
+        ) : (
+          <p class="text-neutral-700">Er zijn op dit moment geen profielen beschikbaar.</p>
+        )}
+      </section>
 
-<section class="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
- {profiles.map((p, idx) => (
+      {cta && (
+        <div class="mt-10">
+          <CTA href={cta.href} label={cta.label} />
+        </div>
+      )}
+    </>
+  ) : (
+    <>
+      <header class="mb-6">
+        <h1 class="text-3xl font-bold text-neutral-900">Datingtips {city}</h1>
+        <p class="text-neutral-700">
+          Hier volgt later uitgebreide content over daten in {city}. Ondertussen alvast een paar profielen uit {province}.
+        </p>
+      </header>
 
-   <ProfileCard {...p} rank={idx + 1} />
-
- ))}
-
-</section>
-
-) : (
-
-<p class="text-neutral-700">Er zijn op dit moment geen profielen beschikbaar uit {province}.</p>
-
-)}
+      {profiles.length > 0 ? (
+        <section class="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {profiles.map((p, idx) => (
+            <ProfileCard {...p} rank={idx + 1} />
+          ))}
+        </section>
+      ) : (
+        <p class="text-neutral-700">Er zijn op dit moment geen profielen beschikbaar uit {province}.</p>
+      )}
+    </>
+  )}
 </Base>

--- a/src/pages/datingtips/[slug]/index.astro
+++ b/src/pages/datingtips/[slug]/index.astro
@@ -1,0 +1,75 @@
+---
+import Base from "../../../layouts/Base.astro";
+import ProfileCard from "../../../components/ProfileCard.astro";
+import CTA from "../../../components/CTA.astro";
+import { getPopular, getProvince } from "../../../lib/api";
+import { getCollection, getEntry } from "astro:content";
+
+type CardProfile = Awaited<ReturnType<typeof getProvince>>["profiles"][number];
+
+type StaticPath = {
+  params: { slug: string };
+  props: { id: string };
+};
+
+export async function getStaticPaths() {
+  const entries = await getCollection("datingtips", (entry) => entry.data.type === "general");
+
+  return entries.map((entry) => {
+    const slug = entry.slug ?? entry.id.split("/").pop() ?? entry.id;
+    return { params: { slug }, props: { id: entry.id } } satisfies StaticPath;
+  });
+}
+
+const { id } = Astro.props as { id: string };
+const entry = await getEntry("datingtips", id);
+const rendered = await entry.render();
+const Content = rendered.Content;
+const data = entry.data;
+
+let profiles: CardProfile[] = [];
+
+try {
+  if (data.profiles.source === "province" && data.province) {
+    const provinceData = await getProvince(data.province, data.profiles.limit, 1);
+    profiles = provinceData.profiles ?? [];
+  } else {
+    const popularData = await getPopular(data.profiles.limit);
+    profiles = popularData ?? [];
+  }
+} catch (error) {
+  profiles = [];
+}
+
+const title = data.title;
+const description = data.metaDescription;
+const intro = data.intro;
+const cta = data.cta;
+---
+<Base title={title} description={description} path={Astro.url.pathname} staging={import.meta.env.STAGING}>
+  <header class="mb-8 space-y-4">
+    <h1 class="text-3xl font-bold text-neutral-900">{title}</h1>
+    <p class="text-neutral-700">{intro}</p>
+  </header>
+
+  <article class="prose max-w-none prose-p:text-neutral-800 prose-headings:text-neutral-900">
+    <Content />
+  </article>
+
+  <section class="mt-10 space-y-4">
+    <h2 class="text-2xl font-semibold text-neutral-900">Voorbeeldprofielen</h2>
+    {profiles.length > 0 ? (
+      <div class="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        {profiles.map((p, idx) => (
+          <ProfileCard {...p} rank={idx + 1} />
+        ))}
+      </div>
+    ) : (
+      <p class="text-neutral-700">Er zijn op dit moment geen profielen beschikbaar.</p>
+    )}
+  </section>
+
+  <div class="mt-10">
+    <CTA href={cta.href} label={cta.label} />
+  </div>
+</Base>


### PR DESCRIPTION
## Summary
- add an Astro content collection for dating tips with schema support for SEO, profile selections, and CTAs
- update the dating tips overview and city detail pages to prefer collection content while falling back to the existing static layout
- add a general dating tips detail route that renders collection entries with intro, body content, profiles, and CTA

## Testing
- npm run lint *(fails: existing lint issues in Base layout and API utilities)*

------
https://chatgpt.com/codex/tasks/task_e_68db71433e14832488d6ca0942188e53