### PR TITLE
Remove slug field from dating tips content

### DIFF
--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -3,7 +3,7 @@ import { defineCollection, z } from "astro:content";
 const tipSchema = z.object({
   title: z.string(),
   type: z.enum(["general","city"]),
-  slug: z.string().optional(),
+  // slug is reserved by Astro; do not put it in the schema
   metaDescription: z.string().min(120).max(180),
   intro: z.string().min(100), // we valideren globaal; niet hard op 250
   city: z.string().optional(),

--- a/src/content/datingtips/dos-en-donts-online.md
+++ b/src/content/datingtips/dos-en-donts-online.md
@@ -1,7 +1,6 @@
 ---
-title: "Do’s en don’ts online"
+title: "Datingtips Do’s en Don’ts online"
 type: "general"
-slug: "dos-en-donts-online"
 metaDescription: "De belangrijkste do’s en don’ts voor online daten: eerlijk zijn, grenzen respecteren, scammen herkennen en veilig afspreken — 18+ en verantwoord."
 intro: |
   Met een paar heldere do’s en don’ts voorkom je gedoe en houd je online daten leuk. We behandelen respectvolle communicatie, grenzen en consent, het herkennen van rode vlaggen en hoe je soepel van chat naar afspreken gaat. Zo date je slimmer, relaxter en veiliger.

--- a/src/content/datingtips/het-eerste-bericht.md
+++ b/src/content/datingtips/het-eerste-bericht.md
@@ -1,7 +1,6 @@
 ---
-title: "Het eerste bericht"
+title: "Datingtips Het eerste bericht"
 type: "general"
-slug: "het-eerste-bericht"
 metaDescription: "Zo schrijf je een eerste bericht dat opvalt: kort, positief en persoonlijk. Tips voor openingszinnen, vervolgvragen en toon — zonder clichés."
 intro: |
   Het eerste bericht zet de toon. Houd het kort, positief en persoonlijk: verwijs naar iets uit iemands profiel, stel een open vraag en vermijd generieke zinnen. In deze gids vind je praktische voorbeelden, do’s & don’ts en manieren om het gesprek natuurlijk op te starten. Zo vergroot je je kans op een leuke reactie en een fijn vervolg.

--- a/src/content/datingtips/veilig-daten.md
+++ b/src/content/datingtips/veilig-daten.md
@@ -1,7 +1,6 @@
 ---
-title: "Veilig daten"
+title: "Datingtips Veilig daten"
 type: "general"
-slug: "veilig-daten"
 metaDescription: "Leer hoe je veilig online date: van profielcontrole en afspreken op openbare plekken tot privacy en grenzen aangeven — altijd 18+ en verantwoord."
 intro: |
   Online daten is leuk en laagdrempelig, maar veiligheid gaat altijd voor. In deze gids krijg je praktische tips om verantwoord te daten: hoe je profielen slim beoordeelt, veilig het eerste contact legt en duidelijke grenzen bewaakt. We bespreken signalen waarop je kunt letten, manieren om je privacy te beschermen en hoe je afspraken maakt op plekken waar jij je prettig voelt. Met een paar eenvoudige gewoontes vergroot je het plezier én verklein je de risico’s. Zo hou je het leuk, respectvol en 18+.


### PR DESCRIPTION
## Summary
- remove the slug property from the dating tips content collection so Astro can manage entry slugs
- drop the slug frontmatter key from the existing dating tip markdown entries while keeping their titles up to date

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68db88d80c8483249897be095de1d867