### PR TITLE
Use shared province helpers in grid

### DIFF
--- a/src/components/ProvinceGrid.astro
+++ b/src/components/ProvinceGrid.astro
@@ -1,19 +1,10 @@
 ---
-const provinces = [
-  'Drenthe','Flevoland','Friesland','Gelderland','Groningen',
-  'Limburg','Noord-Brabant','Noord-Holland','Overijssel',
-  'Utrecht','Zeeland','Zuid-Holland',
-];
-
-const slug = (v: string) =>
-  v.toLowerCase().normalize('NFD')
-    .replace(/\p{Diacritic}/gu, '')
-    .replace(/[^a-z0-9]+/g, '-').replace(/(^-|-$)/g, '');
+import { PROVINCES, provinceToSlug } from "@/lib/provinces";
 ---
 <section class="mx-auto max-w-6xl px-4">
   <div class="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
-    {provinces.map((p) => {
-      const href = `/dating-${slug(p)}/`;
+    {PROVINCES.map((p) => {
+      const href = `/dating-${provinceToSlug(p)}/`;
       return (
         <a
           href={href}


### PR DESCRIPTION
## Summary
- import the shared province constants and slug helper in ProvinceGrid
- reuse PROVINCES and provinceToSlug when rendering province links

## Testing
- pnpm astro build *(fails: network error fetching pnpm package)*

------
https://chatgpt.com/codex/tasks/task_e_68dbaac13a408324a0b1813c2589a7f8