### PR TITLE
Fix province grid import and load JS assets

### DIFF
--- a/src/components/ProvinceGrid.astro
+++ b/src/components/ProvinceGrid.astro
@@ -1,5 +1,5 @@
 ---
-import { PROVINCES, provinceToSlug } from "@/lib/provinces";
+import { PROVINCES, provinceToSlug } from "../../lib/provinces";
 ---
 <section class="mx-auto max-w-6xl px-4">
   <div class="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -88,6 +88,9 @@ const ogData = buildOpenGraph({
     <link rel="stylesheet" href={tailwindHref} />
     <script defer src="/js/nav.js"></script>
     <script defer src="/js/img-fallback.js"></script>
+    {/* 18+ interstitial en analytics waren dode assets; nu actief laden */}
+    <script defer src="/js/age-gate.js"></script>
+    <script defer src="/js/analytics.js"></script>
   </head>
   <body class="flex min-h-screen flex-col bg-neutral-50 text-neutral-900">
     <a


### PR DESCRIPTION
## Summary
- update the province grid to use a working relative import for shared province data
- ensure the base layout loads the age gate and analytics scripts that were previously unused

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dbb382a1948324af8dea7a48a2ef0e