### PR TITLE
Fix height mapping and add breadcrumbs

### DIFF
--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -193,7 +193,7 @@ const profileSchema = rawProfileSchema.transform((raw) => {
   const city = (raw as any).city ?? (raw as any).stad;
   const relationship =
     (raw as any).relationship ?? (raw as any).relatiestatus ?? (raw as any).relationship_status;
-  const height = (raw as any).height ?? (raw as any).lengte;
+  const height = (raw as any).height ?? (raw as any).lengte ?? (raw as any).length;
 
   return {
     id: String(raw.id),

--- a/src/pages/dating-nederland/index.astro
+++ b/src/pages/dating-nederland/index.astro
@@ -2,6 +2,7 @@
 import Base from "../../layouts/Base.astro";
 import ProvinceGrid from "../../components/ProvinceGrid.astro";
 import { buildTitle, buildDescription } from "../../lib/seo";
+import Breadcrumbs from "../../components/Breadcrumbs.astro";
 
 const stagingEnv = import.meta.env.STAGING;
 const staging = stagingEnv === true || stagingEnv === "true";
@@ -12,6 +13,7 @@ const description = buildDescription("generic", {
 });
 ---
 <Base title={title} description={description} path="/dating-nederland/" staging={staging}>
+  <Breadcrumbs items={[{ href: "/", label: "Home" }, { href: "/dating-nederland/", label: "Nederland" }]} />
   <section class="flex flex-col gap-6 rounded-2xl bg-white p-8 shadow-sm">
     <div class="flex flex-col gap-4">
       <h1 class="text-3xl font-semibold text-neutral-900 sm:text-4xl">Dating Nederland: alle provincies in één overzicht</h1>

--- a/src/views/PageView.astro
+++ b/src/views/PageView.astro
@@ -2,6 +2,7 @@
 import Base from "../layouts/Base.astro";
 import ProfileCard from "../components/ProfileCard.astro";
 import Pagination from "../components/Pagination.astro";
+import Breadcrumbs from "../components/Breadcrumbs.astro";
 import { buildTitle, buildDescription, jsonld } from "../lib/seo";
 import type { Profile } from "../lib/api";
 
@@ -56,6 +57,13 @@ const itemListSchema = jsonld("ItemList", {
   og={{ /* laat defaults werken; image valt terug op /og/default.jpg */ }}
 >
   <section class="space-y-6">
+    <Breadcrumbs
+      items={[
+        { href: "/", label: "Home" },
+        { href: "/dating-nederland/", label: "Nederland" },
+        { href: `/dating-${slug}/`, label: provinceName },
+      ]}
+    />
     <div class="space-y-2">
       <h1 class="text-3xl font-bold text-neutral-900">Profielen in {provinceName}</h1>
       <p class="text-neutral-700">


### PR DESCRIPTION
## Summary
- ensure profile normalization reads the API `length` field when `height`/`lengte` are missing
- add breadcrumbs to the national and provincial dating pages for consistent navigation

## Testing
- pnpm astro build *(fails: network error downloading pnpm 8.15.8 via corepack; proxy responded 403)*

------
https://chatgpt.com/codex/tasks/task_e_68ddd6838a408324b587b1f0dce94625