### PR TITLE
Add breadcrumbs to dating tips pages

### DIFF
--- a/src/pages/datingtips-nederland/index.astro
+++ b/src/pages/datingtips-nederland/index.astro
@@ -1,5 +1,6 @@
 ---
 import Base from "../../layouts/Base.astro";
+import Breadcrumbs from "../../components/Breadcrumbs.astro";
 import { CITIES } from "../../lib/cities";
 import { getCollection } from "astro:content";
 
@@ -28,6 +29,7 @@ const findTipForHref = (href: string) => {
 };
 ---
 <Base title={title} description={description} path={Astro.url.pathname} staging={import.meta.env.STAGING}>
+  <Breadcrumbs items={[{ href: "/", label: "Home" }, { href: "/datingtips-nederland/", label: "Datingtips" }]} />
 
 <header class="mb-6">
 <h1 class="text-3xl font-bold text-neutral-900">Datingtips in Nederland</h1>

--- a/src/pages/datingtips/[city]/index.astro
+++ b/src/pages/datingtips/[city]/index.astro
@@ -1,5 +1,6 @@
 ---
 import Base from "../../../layouts/Base.astro";
+import Breadcrumbs from "../../../components/Breadcrumbs.astro";
 import ProfileCard from "../../../components/ProfileCard.astro";
 import CTA from "../../../components/CTA.astro";
 import { CITIES } from "../../../lib/cities";
@@ -59,6 +60,12 @@ let intro: string | undefined;
 let pageProfiles: CardProfile[] = profiles;
 let cta: { label: string; href: string } | undefined;
 
+const breadcrumbItems = [
+  { href: "/", label: "Home" },
+  { href: "/datingtips-nederland/", label: "Datingtips" },
+  { href: Astro.url.pathname, label: `Datingtips ${city}` },
+];
+
 if (matched) {
   const entry = await getEntry("datingtips", matched.id);
   const rendered = await entry.render();
@@ -83,6 +90,7 @@ if (matched) {
 }
 ---
 <Base title={contentTitle} description={contentDescription} path={Astro.url.pathname} staging={import.meta.env.STAGING}>
+  <Breadcrumbs items={breadcrumbItems} />
   {matched && Content ? (
     <>
       <header class="mb-8 space-y-4">

--- a/src/pages/datingtips/[slug]/index.astro
+++ b/src/pages/datingtips/[slug]/index.astro
@@ -44,7 +44,8 @@ try {
 
 const breadcrumbItems = [
   { label: "Home", href: "/" },
-  { label: data.title },
+  { label: "Datingtips", href: "/datingtips-nederland/" },
+  { label: data.title, href: Astro.url.pathname },
 ];
 ---
 <Layout


### PR DESCRIPTION
## Summary
- add breadcrumb navigation to the dating tips overview, city, and article pages
- ensure each page includes Home and Datingtips crumbs with a contextual final crumb

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dde0cec9ac832492a21d9dca99a8b4