### PR TITLE
Prebuild profile pages from CSV data

### DIFF
--- a/public/js/profile-fallback.js
+++ b/public/js/profile-fallback.js
@@ -1,0 +1,56 @@
+// Client fallback: only runs on 404 when a /daten-met-... route wasn't prebuilt.
+(async () => {
+  const path = location.pathname;
+  const match = path.match(/^\/daten-met-[^/]+\/?$/i);
+  if (!match) return;
+  const id = new URLSearchParams(location.search).get("id");
+  if (!id) return;
+  const mount = document.getElementById("profile-view");
+  if (!mount) return;
+  try {
+    // Production-style GET-by-id (same host you already use)
+    const API_BASE = "https://16hl07csd16.nl";
+    const ep = `/profile/id/${encodeURIComponent(String(id))}`;
+    const res = await fetch(API_BASE + ep, { headers: { Accept: "application/json" } });
+    if (!res.ok) throw new Error(String(res.status));
+    const data = await res.json();
+    const p = data?.profile || data?.data || data;
+    if (!p) throw new Error("no profile");
+    const name = p.name || p.title || "";
+    const province = p.province || p.regio || "";
+    const city = p.city || p.stad || "";
+    const age = p.age || p.leeftijd || "";
+    const length = p.length || p.lengte || "";
+    const about = p.aboutme || p.bio || p.description || "";
+    const img =
+      p.profile_image ||
+      p?.img?.src ||
+      p.imageUrl ||
+      p.thumbUrl ||
+      p.src ||
+      "/img/fallback.svg";
+    mount.innerHTML = `
+      <article class="mx-auto grid max-w-5xl grid-cols-1 gap-8 md:grid-cols-[360px,1fr]">
+        <div class="overflow-hidden rounded-2xl border border-neutral-200 bg-white">
+          <img src="${img}" alt="${name}" class="block h-auto w-full object-cover" onerror="this.src='/img/fallback.svg'"/>
+        </div>
+        <div class="space-y-4">
+          <header>
+            <h1 class="text-3xl font-bold text-neutral-900">${name}</h1>
+            <p class="text-neutral-700">${age ? `${age} jaar` : ""}${(age && (city||province)) ? " · " : ""}${city || province}</p>
+          </header>
+          ${about ? `<p class="text-neutral-800 leading-relaxed">${about}</p>` : ""}
+          <section class="mt-2 grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
+            ${province ? `<div class="rounded-xl border border-neutral-200 bg-white p-4"><p class="text-xs uppercase tracking-wide text-neutral-500">Provincie</p><p class="mt-1 font-medium text-neutral-900">${province}</p></div>` : ""}
+            ${city ? `<div class="rounded-xl border border-neutral-200 bg-white p-4"><p class="text-xs uppercase tracking-wide text-neutral-500">Stad</p><p class="mt-1 font-medium text-neutral-900">${city}</p></div>` : ""}
+            ${age ? `<div class="rounded-xl border border-neutral-200 bg-white p-4"><p class="text-xs uppercase tracking-wide text-neutral-500">Leeftijd</p><p class="mt-1 font-medium text-neutral-900">${age}</p></div>` : ""}
+            ${length ? `<div class="rounded-xl border border-neutral-200 bg-white p-4"><p class="text-xs uppercase tracking-wide text-neutral-500">Lengte</p><p class="mt-1 font-medium text-neutral-900">${length}</p></div>` : ""}
+          </section>
+        </div>
+      </article>
+    `;
+    document.title = `Date met ${name}${province ? " in " + province : ""}`;
+  } catch {
+    // leave default 404 content
+  }
+})();

--- a/src/lib/load-profiles.ts
+++ b/src/lib/load-profiles.ts
@@ -1,0 +1,55 @@
+import fs from "node:fs";
+import path from "node:path";
+
+export type CsvProfile = {
+  profile_id: string;
+  profile_name: string;
+  gender?: string;
+  province?: string;
+  city?: string;
+  age?: string | number;
+  length?: string;
+  aboutme?: string;
+  profile_image?: string;
+};
+
+// tiny CSV reader without deps (expects first line header, comma separated, no quoted commas)
+function readCsv(filePath: string): CsvProfile[] {
+  const abs = path.resolve(process.cwd(), filePath);
+  if (!fs.existsSync(abs)) return [];
+  const raw = fs.readFileSync(abs, "utf8");
+  const lines = raw.split(/\r?\n/).filter(Boolean);
+  if (lines.length === 0) return [];
+  const headers = lines[0].split(",").map((h) => h.trim());
+  const rows = lines.slice(1);
+  const records: CsvProfile[] = [];
+  for (const line of rows) {
+    const cols = line.split(",").map((c) => c.trim());
+    const obj: Record<string, string> = {};
+    headers.forEach((h, i) => (obj[h] = cols[i] ?? ""));
+    // normalize keys we expect
+    records.push({
+      profile_id: obj.profile_id,
+      profile_name: obj.profile_name,
+      gender: obj.gender || undefined,
+      province: obj.province || undefined,
+      city: obj.city || undefined,
+      age: obj.age || undefined,
+      length: obj.length || undefined,
+      aboutme: obj.aboutme || undefined,
+      profile_image: obj.profile_image || undefined,
+    });
+  }
+  return records.filter((r) => r.profile_id && r.profile_name);
+}
+
+export function loadAllProfiles() {
+  const primary = readCsv("data/profiles.csv");
+  const extra = readCsv("data/popular.csv");
+  const byId = new Map<string, CsvProfile>();
+  // prefer primary over extra
+  for (const r of [...extra, ...primary]) {
+    if (!byId.has(r.profile_id)) byId.set(r.profile_id, r);
+  }
+  return Array.from(byId.values());
+}

--- a/src/pages/404.html
+++ b/src/pages/404.html
@@ -9,11 +9,16 @@
   </head>
   <body class="bg-neutral-50 text-neutral-900">
     <main id="content" class="mx-auto max-w-5xl px-4 py-10">
+      <!-- Profile fallback mount (populated by /js/profile-fallback.js if path matches /daten-met-... ) -->
+      <div id="profile-view"></div>
+
       <h1 class="text-3xl font-bold text-neutral-900">Pagina niet gevonden</h1>
       <p class="mt-4 max-w-prose text-neutral-700">
-        De opgevraagde pagina bestaat niet. Ga terug naar de <a class="text-sky-600 underline" href="/">homepage</a> of bekijk
-        onze profielen.
+        De opgevraagde pagina bestaat niet. Ga terug naar de <a class="text-sky-600 underline" href="/">homepage</a> of bekijk onze profielen.
       </p>
     </main>
+
+    <!-- Client profile fallback (GET-by-id) -->
+    <script src="/js/profile-fallback.js" type="module"></script>
   </body>
 </html>

--- a/src/pages/daten-met-[slug]/index.astro
+++ b/src/pages/daten-met-[slug]/index.astro
@@ -1,54 +1,49 @@
 ---
 import Base from "../../layouts/Base.astro";
-import { getProvince, getPopular } from "../../lib/api";
-import { PROVINCES } from "../../lib/provinces";
 import { slugifyName } from "../../lib/slug";
+import { loadAllProfiles } from "../../lib/load-profiles";
 
-type CardProfile = Awaited<ReturnType<typeof getProvince>>["profiles"][number];
+type CardProfile = {
+  id: string;
+  name: string;
+  age?: number;
+  province?: string;
+  city?: string;
+  length?: string;
+  description?: string;
+  img?: { src: string; alt: string; srcset?: string; sizes?: string };
+  deeplink?: string;
+};
 
 export async function getStaticPaths() {
-  const pageSize = 60;
+  const csv = loadAllProfiles();
   const paths: { params: { slug: string }; props: { profile: CardProfile } }[] = [];
-  const seen = new Set<string>();
-
-  const push = (profile: CardProfile) => {
-    const slug = slugifyName(profile.name);
-    const key = `${slug}#${profile.id}`;
-    if (seen.has(key)) return;
-    seen.add(key);
-    paths.push({ params: { slug }, props: { profile } });
-  };
-
-  try {
-    const popular = await getPopular(240);
-    for (const p of popular) push(p as CardProfile);
-  } catch {}
-
-  for (const provinceName of PROVINCES) {
-    const first = await getProvince(provinceName, pageSize, 1);
-    const totalPages = first.totalPages ?? 1;
-
-    const collect = async (page: number) => {
-      const data = page === 1 ? first : await getProvince(provinceName, pageSize, page);
-      for (const profile of data.profiles) push(profile);
+  for (const r of csv) {
+    const slug = slugifyName(r.profile_name);
+    const p: CardProfile = {
+      id: String(r.profile_id),
+      name: r.profile_name,
+      age: r.age ? Number(r.age) : undefined,
+      province: r.province,
+      city: r.city,
+      length: r.length,
+      description: r.aboutme,
+      img: r.profile_image ? { src: r.profile_image, alt: r.profile_name } : undefined,
     };
-
-    for (let page = 1; page <= totalPages; page++) {
-      await collect(page);
-    }
+    paths.push({ params: { slug }, props: { profile: p } });
   }
-
   return paths;
 }
 
 const { profile } = Astro.props as { profile: CardProfile };
-const idParam = new URL(Astro.url).searchParams.get("id") ?? String(profile.id);
 
-const title = `Date met ${profile.name} in ${profile.province}`;
+const q = new URL(Astro.url).searchParams;
+const idParam = q.get("id") ?? profile.id;
+
+const title = `Date met ${profile.name}${profile.province ? " in " + profile.province : ""}`;
 const description = profile.description ?? `Leer ${profile.name} kennen en stuur gratis een bericht.`;
 const canonicalPath = `${Astro.url.pathname}?id=${encodeURIComponent(String(idParam))}`;
 
-// Afbeelding + fallback
 const imgSrc = profile.img?.src ?? "/img/fallback.svg";
 const imgAlt = profile.img?.alt ?? profile.name;
 
@@ -58,7 +53,6 @@ const analyticsProps = JSON.stringify({
   chat_url: profile.deeplink,
 });
 
-// JSON-LD minimaal
 const personLd = { "@type": "Person", name: profile.name, description: profile.description ?? undefined };
 ---
 <Base title={title} description={description} path={canonicalPath} staging={import.meta.env.STAGING} jsonLd={[personLd]}>
@@ -70,14 +64,16 @@ const personLd = { "@type": "Person", name: profile.name, description: profile.d
         loading="eager"
         decoding="async"
         class="block h-auto w-full object-cover"
-        data-fallback-src="/img/fallback.svg"
+        data-fallback-src={"/img/fallback.svg"}
       />
     </div>
 
     <div class="space-y-4">
       <header>
         <h1 class="text-3xl font-bold text-neutral-900">{profile.name}</h1>
-        <p class="text-neutral-700">{profile.age} jaar · {profile.city ?? profile.province}</p>
+        <p class="text-neutral-700">
+          {profile.age ? `${profile.age} jaar` : ""}{profile.age && (profile.city || profile.province) ? " · " : ""}{profile.city ?? profile.province}
+        </p>
       </header>
 
       {profile.description && (
@@ -97,39 +93,36 @@ const personLd = { "@type": "Person", name: profile.name, description: profile.d
           </div>
         )}
 
-        <div class="rounded-xl border border-neutral-200 bg-white p-4">
-          <p class="text-xs uppercase tracking-wide text-neutral-500">Leeftijd</p>
-          <p class="mt-1 font-medium text-neutral-900">{profile.age}</p>
-        </div>
-
-        {profile.relationship && (
+        {profile.age && (
           <div class="rounded-xl border border-neutral-200 bg-white p-4">
-            <p class="text-xs uppercase tracking-wide text-neutral-500">Relatiestatus</p>
-            <p class="mt-1 font-medium text-neutral-900">{profile.relationship}</p>
+            <p class="text-xs uppercase tracking-wide text-neutral-500">Leeftijd</p>
+            <p class="mt-1 font-medium text-neutral-900">{profile.age}</p>
           </div>
         )}
 
-        {profile.height && (
+        {profile.length && (
           <div class="rounded-xl border border-neutral-200 bg-white p-4">
             <p class="text-xs uppercase tracking-wide text-neutral-500">Lengte</p>
-            <p class="mt-1 font-medium text-neutral-900">{profile.height}</p>
+            <p class="mt-1 font-medium text-neutral-900">{profile.length}</p>
           </div>
         )}
       </section>
 
-      <div class="pt-2">
-        <a
-          href={profile.deeplink}
-          rel="nofollow sponsored noopener"
-          target="_blank"
-          class="inline-flex items-center justify-center rounded-full bg-sky-600 px-6 py-3 text-base font-semibold text-white transition hover:bg-sky-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-400"
-          aria-label="Stuur gratis bericht"
-          data-analytics="outbound_click"
-          data-props={analyticsProps}
-        >
-          Stuur gratis bericht
-        </a>
-      </div>
+      {profile.deeplink && (
+        <div class="pt-2">
+          <a
+            href={profile.deeplink}
+            rel="nofollow sponsored noopener"
+            target="_blank"
+            class="inline-flex items-center justify-center rounded-full bg-sky-600 px-6 py-3 text-base font-semibold text-white transition hover:bg-sky-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-400"
+            aria-label="Stuur gratis bericht"
+            data-analytics="outbound_click"
+            data-props={analyticsProps}
+          >
+            Stuur gratis bericht
+          </a>
+        </div>
+      )}
     </div>
   </article>
 </Base>


### PR DESCRIPTION
## Summary
- load profile metadata from the CSV exports at build time
- render daten-met detail pages from the preloaded CSV data and prefer CSV images
- add a 404 fallback script that fetches missing profiles by id on demand

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68df8ad7b80c8324b1cfe1bdd64586bc