### PR TITLE
Improve profile CSV parsing and fallback configuration defaults

### DIFF
--- a/public/js/profile-fallback.js
+++ b/public/js/profile-fallback.js
@@ -33,9 +33,19 @@ function pickImage(p, id) {
 }
 
 async function fetchConfig() {
-  const r = await fetch("/site.config.json", { cache: "no-store" });
-  if (!r.ok) throw new Error(`cfg ${r.status}`);
-  return r.json();
+  try {
+    const r = await fetch("/site.config.json", { cache: "no-store" });
+    if (!r.ok) throw new Error(`cfg ${r.status}`);
+    return await r.json();
+  } catch (err) {
+    console.warn("Profile fallback: /site.config.json niet gevonden, gebruik defaults.", err);
+    return {
+      api: {
+        baseUrl: "https://16hl07csd16.nl",
+        endpoints: { profileById: "/profile/id/{id}" }
+      }
+    };
+  }
 }
 
 async function fetchProfileById(id, cfg) {


### PR DESCRIPTION
## Summary
- replace the profile loader with a CSV-aware parser that merges popular and primary data sets
- ensure the client-side profile fallback continues working without site.config.json by falling back to safe defaults

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dfb1630a348324a30c393c812e8923