### PR TITLE
Restore profile CSV SSG fallback

### DIFF
--- a/src/lib/load-profiles.ts
+++ b/src/lib/load-profiles.ts
@@ -20,21 +20,14 @@ function stripQuotes(s: string) {
 }
 
 function splitSafe(line: string, delim: string): string[] {
-  // Eenvoudige CSV-splitter met quote-ondersteuning (geen escaped quotes nodig in onze data)
+  // simpele CSV-splitter met quotesupport (voldoende voor onze data)
   const out: string[] = [];
   let cur = "";
   let inQuotes = false;
   for (let i = 0; i < line.length; i++) {
     const ch = line[i];
-    if (ch === '"') {
-      inQuotes = !inQuotes;
-      continue;
-    }
-    if (ch === delim && !inQuotes) {
-      out.push(cur);
-      cur = "";
-      continue;
-    }
+    if (ch === '"') { inQuotes = !inQuotes; continue; }
+    if (ch === delim && !inQuotes) { out.push(cur); cur = ""; continue; }
     cur += ch;
   }
   out.push(cur);
@@ -46,14 +39,12 @@ function parseCsv(text: string): CsvProfile[] {
   if (lines.length === 0) return [];
   const headerLine = lines[0];
   const delim = headerLine.includes(";") ? ";" : ",";
-  const headers = headerLine.split(delim).map((h) => stripQuotes(h));
+  const headers = headerLine.split(delim).map(stripQuotes);
   const rows: CsvProfile[] = [];
   for (let i = 1; i < lines.length; i++) {
     const cells = splitSafe(lines[i], delim).map(stripQuotes);
     const rec: Record<string, string> = {};
-    for (let c = 0; c < headers.length; c++) {
-      rec[headers[c]] = cells[c] ?? "";
-    }
+    for (let c = 0; c < headers.length; c++) rec[headers[c]] = cells[c] ?? "";
     rows.push(rec as CsvProfile);
   }
   return rows;
@@ -67,13 +58,12 @@ function readCsv(relPath: string): CsvProfile[] {
 }
 
 export function loadAllProfiles(): CsvProfile[] {
-  // Merge, met voorkeur voor 'profiles.csv' waarden
+  // Merge popular + primary; primary mag overschrijven
   const primary = readCsv("data/profiles.csv");
   const popular = readCsv("data/popular.csv");
   const byId = new Map<string, CsvProfile>();
   for (const row of [...popular, ...primary]) {
     if (!row?.profile_id || !row?.profile_name) continue;
-    // primary overschrijft popular: daarom duwen we 'popular' eerst
     byId.set(String(row.profile_id), row);
   }
   return Array.from(byId.values());

--- a/src/lib/slug.ts
+++ b/src/lib/slug.ts
@@ -6,7 +6,6 @@ export function slugifyName(name: string) {
     .replace(/[^a-z0-9]+/g, "-")
     .replace(/(^-|-$)/g, "");
 }
-
 /** Bouw de canonieke interne profiel-URL, altijd met trailing slash. */
 export function buildProfileHref(name: string, id: string | number) {
   const slug = slugifyName(name);

--- a/src/pages/404.html
+++ b/src/pages/404.html
@@ -141,11 +141,18 @@
   </head>
   <body>
     <main id="content" style="max-width:64rem;margin:0 auto;padding:3rem 1.5rem;font-family:system-ui,-apple-system,'Segoe UI',Roboto,Inter,sans-serif;line-height:1.6">
-      <h1 style="margin:0 0 .5rem;font-size:2rem">Pagina niet gevonden</h1>
-      <p style="margin:0;color:#475569">
-        De opgevraagde pagina bestaat niet. Ga terug naar de
-        <a href="/">homepage</a> of bekijk onze profielen.
-      </p>
+      <!-- Fallback mount voor profielroutes -->
+      <div id="profile-view" class="profile-view"></div>
+
+      <!-- Standaard 404 content (zichtbaar als route geen profiel is) -->
+      <section id="not-found">
+        <h1 style="margin:0 0 .5rem;font-size:2rem">Pagina niet gevonden</h1>
+        <p style="margin:0;color:#475569">
+          De opgevraagde pagina bestaat niet. Ga terug naar de
+          <a href="/">homepage</a> of bekijk onze profielen.
+        </p>
+      </section>
     </main>
+    <script type="module" src="/js/profile-fallback.js"></script>
   </body>
 </html>

--- a/src/pages/daten-met-[slug]/index.astro
+++ b/src/pages/daten-met-[slug]/index.astro
@@ -1,72 +1,26 @@
 ---
 import Base from "../../layouts/Base.astro";
+import { loadAllProfiles } from "../../lib/load-profiles";
 import { slugifyName } from "../../lib/slug";
-import fs from "node:fs";
-import path from "node:path";
-
-// --- CSV helpers (in-scope voor getStaticPaths) ---
-type CsvRow = {
-  profile_id: string;
-  profile_name: string;
-  province?: string;
-  city?: string;
-  age?: string;
-  length?: string;
-  aboutme?: string;
-  profile_image?: string;
-};
-
-function readCsv(filePath: string): CsvRow[] {
-  // Gebruik process.cwd() i.p.v. Astro.root.pathname om paden stabiel te resolven in build.
-  const abs = path.resolve(process.cwd(), filePath);
-  if (!fs.existsSync(abs)) return [];
-  const text = fs.readFileSync(abs, "utf8");
-  const lines = text.split(/\r?\n/).filter(Boolean);
-  if (lines.length === 0) return [];
-  const headerLine = lines[0];
-  const headers = headerLine.split(",").map((h) => h.trim());
-  const rows = lines.slice(1);
-  return rows.map((ln) => {
-    // Eenvoudige CSV parser (veldnamen zonder quotes/comma’s in velden)
-    const cols = ln.split(",").map((c) => c.trim());
-    const row: Record<string, string> = {};
-    headers.forEach((h, i) => {
-      row[h] = cols[i] ?? "";
-    });
-    return row as CsvRow;
-  });
-}
 
 export async function getStaticPaths() {
-  try {
-    const a = readCsv("data/profiles.csv");
-    const b = readCsv("data/popular.csv");
-    const byId = new Map<string, CsvRow>();
-    for (const r of [...a, ...b]) {
-      if (!r?.profile_id) continue;
-      if (!byId.has(r.profile_id)) byId.set(r.profile_id, r);
-    }
-    if (byId.size === 0) return [];
-    const paths = Array.from(byId.values()).map((r) => ({
-      params: { slug: slugifyName(r.profile_name ?? r.profile_id) },
-      props: {
-        ssrProfile: {
-          id: String(r.profile_id),
-          name: r.profile_name ?? "",
-          province: r.province ?? "",
-          city: r.city ?? "",
-          age: r.age ? Number.parseInt(r.age, 10) : undefined,
-          height: r.length ?? "",
-          description: r.aboutme ?? "",
-          img: { src: r.profile_image ?? "/img/fallback.svg", alt: r.profile_name ?? "Profielafbeelding" },
-        },
+  const rows = loadAllProfiles();
+  const paths = rows.map((r) => ({
+    params: { slug: slugifyName(r.profile_name ?? r.profile_id) },
+    props: {
+      ssrProfile: {
+        id: String(r.profile_id),
+        name: r.profile_name ?? "",
+        province: r.province ?? "",
+        city: r.city ?? "",
+        age: r.age ? Number.parseInt(r.age, 10) : undefined,
+        height: r.length ?? "",
+        description: r.aboutme ?? "",
+        img: { src: r.profile_image ?? "/img/fallback.svg", alt: r.profile_name ?? "Profielafbeelding" },
       },
-    }));
-    return paths;
-  } catch {
-    // Fail-safe: geen crash bij tijdelijk leesprobleem
-    return [];
-  }
+    },
+  }));
+  return paths;
 }
 
 const { ssrProfile } = Astro.props as {


### PR DESCRIPTION
## Summary
- add a robust CSV loader that merges profile datasets and reuse it from the profile route SSG
- restore the profile fallback mount/script on the 404 page and make the client fallback resilient to a missing site.config.json
- expose a helper for building canonical profile links used by the profile cards

## Testing
- npm run lint *(fails: pre-existing lint violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68dfb4f5a0148324adf3925516f1c0fe